### PR TITLE
Use sql attr for plrust_call_handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,10 @@ fn _PG_init() {
 
 /// `pgx` doesn't know how to declare a CREATE FUNCTION statement for a function
 /// whose only argument is a `pg_sys::FunctionCallInfo`, so we gotta do that ourselves.
-///
-/// ```pgxsql
-/// CREATE OR REPLACE FUNCTION plrust_call_handler() RETURNS language_handler
-///     LANGUAGE c AS 'MODULE_PATHNAME', 'plrust_call_handler_wrapper';
-/// ```
-#[pg_extern]
+#[pg_extern(sql = "
+CREATE OR REPLACE FUNCTION plrust_call_handler() RETURNS language_handler
+    LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+")]
 unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     let fn_oid = fcinfo.as_ref().unwrap().flinfo.as_ref().unwrap().fn_oid;
     let func = plrust::lookup_function(fn_oid);


### PR DESCRIPTION
`pgx` 0.4.0 series has good support for this new attribute and it removes the rather confusing documentation otherwise generated.