### PR TITLE
Add SQL functions to cleanup PL/Rust scratch space

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,24 @@ fn recompile_function(
     }
 }
 
+#[pg_extern]
+fn list_function_in_work_dir() -> impl std::iter::Iterator<Item = String> {
+    plrust::list_functions()
+}
+
+#[pg_extern]
+fn remove_fn_from_work_dir(fn_oid: pg_sys::Oid, schema_name: String) {
+    let removed = plrust::remove_fn_from_work_dir(fn_oid, schema_name);
+    if !removed {
+        panic!("No file was removed")
+    }
+}
+
+#[pg_extern]
+fn remove_fn_from_work_dir_priviliged(basename: String) {
+    plrust::remove_file_from_work_dir(basename);
+}
+
 extension_sql!(
     r#"
 CREATE LANGUAGE plrust


### PR DESCRIPTION
```
When a function is dropped, the corresponding files
in the scratch directory are not cleaned up. Since
PL/Rust could be used in environments where the users
do not have access to the filesystem or superuser, have
it provide mechanisms to cleanup stale files in the
scratch directory.
```

Creating this pull request to get the conversation started whether or not this is useful. I still need to do some testing, and there's probably a lot of the Rust that can be simplified into more rust-isms (that I need to learn...)

There's some cleaning up that still needs to be done, mainly this still exposes metadata information about other directory but basic sanity tests seem to pass, see testing section.

I also wasn't too sure how to actually write tests for this within PL/Rust itself, any suggestions on this part?


The initial goal of this was to create enough wrapper functions, mainly `plrust.remove_fn_from_work_dir`  so that it could be dropped automatically via event triggers. I had an idea that on `DROP FUNCTION` we could clean up the corresponding scratch space on `sql_drop` [0]


It doesn't seem as nice as I would want it to be since the event [1] only contains information about the schema name, and the fn_oid. There isn't information if it's a PL/Rust function or not. Although I suppose it doesn't hurt to create an EVENT TRIGGER that on every drop function just checks if there's a corresponding format in the scratch space and remove accordingly, which sounds like it'd work?

If the user was superuser (pg_ls_dir + COPY TO PROGRAM 'rm /scratch/foo' this isn't necessary but these aren't necessarily available to all users.


**Testing**

```
plrust=# select plrust.list_function_in_work_dir();
                     list_function_in_work_dir                     
-------------------------------------------------------------------
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40980_0.so
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_57497_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/.rustc_info.json
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40980_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/plrust_interface
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_57497_0.so
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40979
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40977
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_0_40980
(9 rows)

-- test remove directory
plrust=# set session authorization testuser;
SET
plrust=> select plrust.remove_fn_from_work_dir_priviliged('fn16384_0_40980');
ERROR:  Only superusers are allowed to remove arbitrary files
CONTEXT:  src/plrust.rs:246:9
plrust=> reset session authorization;
RESET
plrust=# select plrust.remove_fn_from_work_dir_priviliged('fn16384_0_40980');
 remove_fn_from_work_dir_priviliged 
------------------------------------
 
(1 row)

plrust=# select plrust.list_function_in_work_dir();                                                                                                                                                    list_function_in_work_dir                     
-------------------------------------------------------------------
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40980_0.so
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_57497_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/.rustc_info.json
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40980_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/plrust_interface
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_57497_0.so
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40979
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40977
(8 rows)

-- test remove file
plrust=# select plrust.remove_fn_from_work_dir_priviliged('fn16384_2200_57497_0.so');
 remove_fn_from_work_dir_priviliged 
------------------------------------
 
(1 row)

plrust=# select count(*) from plrust.list_function_in_work_dir();
 count 
-------
     7
(1 row)

-- test remove file that is somewhere else TODO: fix leaks information about files 
plrust=# select plrust.remove_fn_from_work_dir_priviliged('../fn16384_2200_57497_0.so');
ERROR:  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
CONTEXT:  src/plrust.rs:249:70
plrust=# select plrust.remove_fn_from_work_dir_priviliged('../test');
ERROR:  Unable to remove a file not in the work directory
CONTEXT:  src/plrust.rs:252:9

plrust=# select plrust.list_function_in_work_dir();
                     list_function_in_work_dir                     
-------------------------------------------------------------------
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40980_0.so
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_57497_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/.rustc_info.json
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40980_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/plrust_interface
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40979
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40977
(7 rows)

plrust=# select plrust.remove_fn_from_work_dir(40980, 'public');
 remove_fn_from_work_dir 
-------------------------
 
(1 row)

plrust=# select plrust.list_function_in_work_dir();
                     list_function_in_work_dir                     
-------------------------------------------------------------------
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_57497_1.so
 /Users/hsuchen/git/zombodb/plrust/scratch/.rustc_info.json
 /Users/hsuchen/git/zombodb/plrust/scratch/plrust_interface
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40979
 /Users/hsuchen/git/zombodb/plrust/scratch/fn16384_2200_40977
(5 rows)
```

-------
[0] https://www.postgresql.org/docs/current/event-trigger-definition.html
[1] https://www.postgresql.org/docs/current/functions-event-triggers.html#PG-EVENT-TRIGGER-SQL-DROP-FUNCTIONS