### PR TITLE
Use DLL_SUFFIX to address cross-platform todo

### DIFF
--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -289,11 +289,9 @@ fn crate_name_and_path(fn_oid: pg_sys::Oid) -> (String, PathBuf) {
 }
 
 fn find_shared_library(crate_name: &str) -> (Option<PathBuf>, &str) {
-    let work_dir = gucs::work_dir();
-    let mut target_dir = work_dir.clone();
-    target_dir.push("release");
-
+    let target_dir = gucs::work_dir().join("release");
     let so = target_dir.join(&format!("lib{crate_name}{DLL_SUFFIX}"));
+
     if so.exists() {
         (Some(so), crate_name)
     } else {


### PR DESCRIPTION
This changes all the compiling function steps to use whatever the platform's name for dylibs is instead, making it cross platform to an almost unnecessary degree by removing the guesswork involved.