### PR TITLE
Eagerly unwrap argtypes

### DIFF
--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -434,8 +434,7 @@ fn extract_code_and_args(
             pg_sys::Anum_pg_proc_proargnames as pg_sys::AttrNumber,
             &mut is_null,
         );
-        let argnames =
-            Vec::<Option<String>>::from_datum(argnames_datum, is_null, pg_sys::TEXTARRAYOID);
+        let argnames = Vec::<Option<_>>::from_datum(argnames_datum, is_null, pg_sys::TEXTARRAYOID);
 
         let argtypes_datum = pg_sys::SysCacheGetAttr(
             pg_sys::SysCacheIdentifier_PROCOID as i32,
@@ -443,8 +442,7 @@ fn extract_code_and_args(
             pg_sys::Anum_pg_proc_proargtypes as pg_sys::AttrNumber,
             &mut is_null,
         );
-        let argtypes =
-            Vec::<pg_sys::Oid>::from_datum(argtypes_datum, is_null, pg_sys::OIDARRAYOID).unwrap();
+        let argtypes = Vec::<_>::from_datum(argtypes_datum, is_null, pg_sys::OIDARRAYOID).unwrap();
 
         let proc_entry = PgBox::from_pg(heap_tuple_get_struct::<pg_sys::FormData_pg_proc>(
             proc_tuple,

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -435,8 +435,7 @@ fn extract_code_and_args(
             &mut is_null,
         );
         let argnames =
-            Vec::<Option<String>>::from_datum(argnames_datum, is_null, pg_sys::TEXTARRAYOID)
-                .unwrap();
+            Vec::<Option<String>>::from_datum(argnames_datum, is_null, pg_sys::TEXTARRAYOID);
 
         let argtypes_datum = pg_sys::SysCacheGetAttr(
             pg_sys::SysCacheIdentifier_PROCOID as i32,
@@ -453,13 +452,10 @@ fn extract_code_and_args(
 
         let mut args = Vec::new();
         for i in 0..proc_entry.pronargs as usize {
-            let type_oid = argtypes.get(i);
-            let name = argnames.get(i).cloned().flatten();
+            let type_oid = argtypes.get(i).expect("no type_oid for argument");
+            let name = argnames.as_ref().and_then(|v| v.get(i).cloned()).flatten();
 
-            args.push((
-                PgOid::from(*type_oid.expect("no type_oid for argument")),
-                name,
-            ));
+            args.push((PgOid::from(*type_oid), name));
         }
 
         let is_strict = proc_entry.proisstrict;


### PR DESCRIPTION
This is being expected to be available several times anyways, so
instead just unwrap once, reducing the layers of nesting required.