### PR TITLE
"post-alloc" skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,12 +683,13 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
+checksum = "8a08e755adbc0ad283725b29f4a4883deee15336f372d5f61fae59efec40f983"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version 0.4.0",
  "spin",
  "stable_deref_trait",
 ]
@@ -764,9 +765,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -1044,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541daadd2b8b6bcbcca8772c03dcdec968f97ea54e0faca7b0299a8eec4e6869"
+checksum = "00f3f571b70d230cba9ec46c530000469710ef2c1ea3eadf56d7bc8a62b3510c"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1072,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90af33a34d24228eedae09bd34f6c57a8f89dcc910bd5b6d08dac1c4816b17c3"
+checksum = "b854e9b42fa8940b5fa393915df75db559384f14663c8966eb5161b554ff5842"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1085,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b93a0a406092cd49372344542f1e04f009203c746060d76b9014cb144e7bbb8"
+checksum = "57be652efd8d69525ba4ec04743b2aa2feb024ef7c5d39d35f9bf5638bf64d48"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1107,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c08b94a24472166ca4bb57ecf1ef3a6db37b25e58b5a9a3c3ade8b322fef36"
+checksum = "e9012d509f69898cc15762c3feb78b6a61b3a66a533084351f6afe89c78b8e47"
 dependencies = [
  "eyre",
  "libc",
@@ -1128,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8719c1423a83062bd22670f9d9e2e7bb1cf2044c57e9b74986f421641f3841"
+checksum = "ce5d334b177a9cd741521d01ebea505417adddaef4d368753b34ac4a43052674"
 dependencies = [
  "atty",
  "convert_case",
@@ -1281,11 +1282,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1398,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1553,6 +1554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.9",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1612,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "semver-parser"
@@ -1775,20 +1791,20 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "syntect"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
 dependencies = [
  "bincode",
  "bitflags",
@@ -1796,12 +1812,13 @@ dependencies = [
  "flate2",
  "fnv",
  "lazy_static",
- "lazycell",
+ "once_cell",
  "plist",
  "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
  "walkdir",
  "yaml-rust",
 ]
@@ -2045,6 +2062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,12 +2075,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pg_test = []
 sandboxed = []
 
 [dependencies]
-pgx = "0.4.4"
+pgx = "=0.4.5"
 libloading = "0.7.2"
 thiserror = "1.0"
 eyre = "0.6"
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
 tracing-error = "0.2"
 
 [dev-dependencies]
-pgx-tests = "0.4.4"
+pgx-tests = "=0.4.5"
 tempdir = "0.3.7"
 once_cell = "1.7.2"
 toml = "0.5.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,13 @@ mod tests {
                 use zalgo::{Generator, GeneratorArgs, ZalgoSize};
 
                 let mut generator = Generator::new();
+                log!("gen created");
                 let mut out = String::new();
+                log!("string created");
                 let args = GeneratorArgs::new(true, false, false, ZalgoSize::Maxi);
+                log!("args created");
                 let result = generator.gen(input, &mut out, &args);
+                log!("should be returning?");
 
                 Some(out)
             $$;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,6 @@ pub mod pg_test {
     });
 
     pub fn setup(_options: Vec<&str>) {
-        pgx::initialize();
         // perform one-off initialization when the pg_test framework starts
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,7 @@ pub mod pg_test {
     });
 
     pub fn setup(_options: Vec<&str>) {
+        pgx::initialize();
         // perform one-off initialization when the pg_test framework starts
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,47 @@ mod tests {
         );
         assert!(retval.is_some());
     }
+
+    /// This is currently just a copy of test_deps
+    #[pg_test]
+    #[cfg(not(feature = "sandboxed"))]
+    #[search_path(@extschema@)]
+    fn test_naughty() {
+        if let Ok(path) = std::env::var("experimental_crates") {
+            let definition = format!(r#"
+                CREATE FUNCTION zalgo(input TEXT) RETURNS TEXT
+                    IMMUTABLE STRICT
+                    LANGUAGE PLRUST AS
+                $$
+                [dependencies]
+                    zalgo = "0.2.0"
+                    malicious-dep = {{ path = "{path}/malicious-dep" }}
+                [code]
+                    use zalgo::{{Generator, GeneratorArgs, ZalgoSize}};
+                    use malicious_dep::naughty_api;
+
+                    naughty_api();
+                    let mut generator = Generator::new();
+                    let mut out = String::new();
+                    let args = GeneratorArgs::new(true, false, false, ZalgoSize::Maxi);
+                    let result = generator.gen(input, &mut out, &args);
+
+                    Some(out)
+                $$;
+            "#);
+            Spi::run(&definition);
+
+            let retval: Option<String> = Spi::get_one_with_args(
+                r#"
+                SELECT zalgo($1);
+            "#,
+                vec![(PgBuiltInOids::TEXTOID.oid(), "Nami".into_datum())],
+            );
+            assert!(retval.is_some());
+        } else {
+            return
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,8 @@ mod tests {
     #[search_path(@extschema@)]
     fn test_naughty() {
         if let Ok(path) = std::env::var("experimental_crates") {
-            let definition = format!(r#"
+            let definition = format!(
+                r#"
                 CREATE FUNCTION zalgo(input TEXT) RETURNS TEXT
                     IMMUTABLE STRICT
                     LANGUAGE PLRUST AS
@@ -273,7 +274,8 @@ mod tests {
 
                     Some(out)
                 $$;
-            "#);
+            "#
+            );
             Spi::run(&definition);
 
             let retval: Option<String> = Spi::get_one_with_args(
@@ -284,7 +286,7 @@ mod tests {
             );
             assert!(retval.is_some());
         } else {
-            return
+            return;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ mod tests {
                 let mut generator = Generator::new();
                 let mut out = String::new();
                 let args = GeneratorArgs::new(true, false, false, ZalgoSize::Maxi);
-                let result = generator.gen(input, &mut out, &args);
+                let _result = generator.gen(input, &mut out, &args);
 
                 Some(out)
             $$;
@@ -270,7 +270,7 @@ mod tests {
                     let mut generator = Generator::new();
                     let mut out = String::new();
                     let args = GeneratorArgs::new(true, false, false, ZalgoSize::Maxi);
-                    let result = generator.gen(input, &mut out, &args);
+                    let _result = generator.gen(input, &mut out, &args);
 
                     Some(out)
                 $$;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,13 +229,9 @@ mod tests {
                 use zalgo::{Generator, GeneratorArgs, ZalgoSize};
 
                 let mut generator = Generator::new();
-                log!("gen created");
                 let mut out = String::new();
-                log!("string created");
                 let args = GeneratorArgs::new(true, false, false, ZalgoSize::Maxi);
-                log!("args created");
                 let result = generator.gen(input, &mut out, &args);
-                log!("should be returning?");
 
                 Some(out)
             $$;

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -231,7 +231,7 @@ fn create_function_crate(fn_oid: pg_sys::Oid, crate_dir: &PathBuf, crate_name: &
     std::fs::write(
         &cargo_toml,
         &format!(
-                r#"[package]
+            r#"[package]
 name = "{crate_name}"
 version = "0.0.0"
 edition = "2021"
@@ -253,16 +253,17 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 "#,
-        experimental_deps = match std::env::var("experimental_crates") {
-            Err(_) => String::from(""),
-            Ok(path) => format!(
-                r#"
+            experimental_deps = match std::env::var("experimental_crates") {
+                Err(_) => String::from(""),
+                Ok(path) => format!(
+                    r#"
 [dependencies.std]
 path = "{path}/post-std"
 version = "*"
-"#)
-        },
-            ),
+"#
+                ),
+            },
+        ),
     )
     .expect("failed to write Cargo.toml");
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -259,7 +259,7 @@ crate-type = ["cdylib"]
 default = ["pgx/pg{major_version}"]
 
 [dependencies]
-pgx = "0.4.3"
+pgx = "=0.4.5"
 {deps}
 {experimental_deps}
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -248,6 +248,7 @@ pgx = "0.4.3"
 {experimental_deps}
 
 [profile.release]
+debug-assertions = true
 panic = "unwind"
 opt-level = 3
 lto = "fat"
@@ -318,6 +319,7 @@ fn generate_function_source(
     // #[cfg_attr()]
     source.push_str(
         r#"
+#![feature(c_unwind)]
 #![no_std]
 extern crate alloc;
 #[allow(unused_imports)]
@@ -328,7 +330,7 @@ use alloc::{
 "#,
     );
 
-    source.push_str(include_str!("./postalloc.rs"));
+    // source.push_str(include_str!("./postalloc.rs"));
     // source header
     source.push_str("\nuse pgx::*;\n");
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -330,7 +330,7 @@ use alloc::{
 "#,
     );
 
-    // source.push_str(include_str!("./postalloc.rs"));
+    source.push_str(include_str!("./postalloc.rs"));
     // source header
     source.push_str("\nuse pgx::*;\n");
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -256,17 +256,7 @@ codegen-units = 1
 "#,
             experimental_deps = match std::env::var("experimental_crates") {
                 Err(_) => String::from(""),
-                Ok(path) => format!(
-                    r#"
-[dependencies.std]
-path = "{path}/post-std"
-version = "*"
-
-
-[patch.crates-io.pgx]
-path = "{path}/pgx-hack/pgx"
-"#
-                ),
+                Ok(path) => format!("[patch.crates-io.pgx]\npath = \"{path}/pgx\"\n"),
             },
         ),
     )
@@ -319,7 +309,6 @@ fn generate_function_source(
     // #[cfg_attr()]
     source.push_str(
         r#"
-#![feature(c_unwind)]
 #![no_std]
 extern crate alloc;
 #[allow(unused_imports)]

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -300,17 +300,19 @@ fn generate_function_source(
     is_strict: bool,
 ) -> String {
     let mut source = String::new();
-/*
-    source.push_str(r#"
+    // #[cfg_attr()]
+    source.push_str(
+        r#"
 #![no_std]
 extern crate alloc;
 #[allow(unused_imports)]
-use alloc::{format,
+use alloc::{
     string::String,
     vec,
     vec::Vec};
-"#);
-*/
+"#,
+    );
+
     source.push_str(include_str!("./postalloc.rs"));
 
     // source header

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -176,7 +176,7 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> Result<(PathBuf, String),
     let cargo_output = Command::new("cargo")
         .current_dir(&crate_dir)
         .arg("rustc")
-        .arg("--release")
+        // .arg("--release")
         .arg("--offline")
         .env("PGX_PG_CONFIG_PATH", gucs::pg_config())
         .env("CARGO_TARGET_DIR", &work_dir)
@@ -292,7 +292,7 @@ fn crate_name_and_path(fn_oid: pg_sys::Oid) -> (String, PathBuf) {
 }
 
 fn find_shared_library(crate_name: &str) -> (Option<PathBuf>, &str) {
-    let target_dir = gucs::work_dir().join("release");
+    let target_dir = gucs::work_dir().join("debug");
     let so = target_dir.join(&format!("lib{crate_name}{DLL_SUFFIX}"));
 
     if so.exists() {
@@ -324,8 +324,7 @@ use alloc::{
 "#,
     );
 
-    source.push_str(include_str!("./postalloc.rs"));
-
+    // source.push_str(include_str!("./postalloc.rs"));
     // source header
     source.push_str("\nuse pgx::*;\n");
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -270,7 +270,7 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 "#,
-            experimental_deps = match std::env::var("experimental_crates") {
+            experimental_deps = match std::env::var("PLRUST_EXPERIMENTAL_CRATES") {
                 Err(_) => String::from(""),
                 Ok(path) => format!("[patch.crates-io.pgx]\npath = \"{path}/pgx\"\n"),
             },

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -300,6 +300,7 @@ fn generate_function_source(
     is_strict: bool,
 ) -> String {
     let mut source = String::new();
+/*
     source.push_str(r#"
 #![no_std]
 extern crate alloc;
@@ -309,6 +310,7 @@ use alloc::{format,
     vec,
     vec::Vec};
 "#);
+*/
     source.push_str(include_str!("./postalloc.rs"));
 
     // source header

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -328,7 +328,7 @@ use alloc::{
 "#,
     );
 
-    // source.push_str(include_str!("./postalloc.rs"));
+    source.push_str(include_str!("./postalloc.rs"));
     // source header
     source.push_str("\nuse pgx::*;\n");
 

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,8 +1,17 @@
 use core::alloc::{GlobalAlloc, Layout};
 use core::sync::atomic::{AtomicUsize, Ordering};
-use std::io::Write;
+// use std::io::Write;
 use pgx::pg_sys::{self, SPI_palloc, SPI_pfree};
 use pgx::log;
+
+// SPI_palloc:
+//
+// Allocates using Postgres' "server programming interface".
+// This means it uses a more durable memory context than the most transitory one: it pushes the allocation into the context that was used before the allocator.
+// This is suitable for the "global allocator" but may not necessarily be the best one to use in general.
+// 
+// 
+// SPI_pfree:
 
 struct PostAlloc;
 
@@ -11,23 +20,32 @@ static PALLOC: PostAlloc = PostAlloc;
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+// static ALLOC_REPORT: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+
 unsafe impl GlobalAlloc for PostAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let mut buf = [0u8; 256];
-        let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
-        let mut msg = &mut buf;
-        (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
-        msg[255] = 0; // Guarantee null termination for the C writer.
-        pg_sys::write_stderr(msg as *const _ as *const i8);
+        // #[cfg(feature = "std")]
+        // {
+            // let mut buf = [0u8; 256];
+            // let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
+            // let mut msg = &mut buf;
+            // (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
+            // msg[255] = 0; // Guarantee null termination for the C writer.
+            // pg_sys::write_stderr(msg as *const _ as *const i8);
+        // }
         SPI_palloc(layout.size()).cast()
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        let mut buf = [0u8; 256];
-        let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
-        let mut msg = &mut buf;
-        (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
-        msg[255] = 0; // Guarantee null termination for the C writer.
-        pg_sys::write_stderr(msg as *const _ as *const i8);
+        // if let Ok(&mut txt) = ALLOC_REPORT.get_mut() {
+        // #[cfg(feature = "std")]
+        // {
+            // let mut buf = [0u8; 256];
+            // let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
+            // let mut msg = &mut buf;
+            // (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
+            // msg[255] = 0; // Guarantee null termination for the C writer.
+            // pg_sys::write_stderr(msg as *const _ as *const i8);
+        // }
         SPI_pfree(ptr.cast())
     }
 }

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,4 +1,3 @@
-extern crate std;
 use core::alloc::{GlobalAlloc, Layout};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Write;

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -14,4 +14,8 @@ unsafe impl GlobalAlloc for PostAlloc {
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         pg_sys::pfree(ptr.cast());
     }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
+        pg_sys::repalloc(ptr.cast(), new_size).cast()
+    }
 }

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,5 +1,7 @@
 use core::alloc::{GlobalAlloc, Layout};
-use pgx::pg_sys::{self, SPI_palloc, SPI_repalloc, SPI_pfree};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::io::Write;
+use pgx::pg_sys::{self, SPI_palloc, SPI_pfree};
 use pgx::log;
 
 struct PostAlloc;
@@ -7,14 +9,24 @@ struct PostAlloc;
 #[global_allocator]
 static PALLOC: PostAlloc = PostAlloc;
 
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 unsafe impl GlobalAlloc for PostAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let msg = "attempt to emit alloc message from custom allocator";
+        let mut buf = [0u8; 256];
+        let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
+        let mut msg = &mut buf;
+        (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
+        msg[255] = 0; // Guarantee null termination for the C writer.
         pg_sys::write_stderr(msg as *const _ as *const i8);
         SPI_palloc(layout.size()).cast()
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        let msg = "attempt to emit dealloc message from custom allocator";
+        let mut buf = [0u8; 256];
+        let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
+        let mut msg = &mut buf;
+        (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
+        msg[255] = 0; // Guarantee null termination for the C writer.
         pg_sys::write_stderr(msg as *const _ as *const i8);
         SPI_pfree(ptr.cast())
     }

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -36,7 +36,7 @@ unsafe impl GlobalAlloc for PostAlloc {
         if !pg_sys::CurrentMemoryContext.is_null() {
             pg_sys::SPI_palloc(layout.size()).cast()
         } else {
-            pg_sys::SPI_palloc(layout.size()).cast()
+            pg_sys::palloc(layout.size()).cast()
         }
     }
 

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,0 +1,19 @@
+use core::alloc::{GlobalAlloc, Layout};
+use pgx::pg_sys::{SPI_palloc, SPI_repalloc, SPI_pfree};
+use pgx::log;
+
+struct PostAlloc;
+
+#[global_allocator]
+static PALLOC: PostAlloc = PostAlloc;
+
+unsafe impl GlobalAlloc for PostAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        log!("allocated using custom allocator!");
+        SPI_palloc(layout.size()).cast()
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        log!("deallocated using custom allocator!");
+        SPI_pfree(ptr.cast())
+    }
+}

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,56 +1,17 @@
 use core::alloc::{GlobalAlloc, Layout};
-use core::sync::atomic::{AtomicUsize, Ordering};
-// use std::io::Write;
 use pgx::pg_sys;
-use pgx::log;
-
-// SPI_palloc:
-//
-// Allocates using Postgres' "server programming interface".
-// This means it uses a more durable memory context than the most transitory one: it pushes the allocation into the context that was used before the allocator.
-// This is suitable for the "global allocator" but may not necessarily be the best one to use in general.
-// 
-// 
-// SPI_pfree:
 
 struct PostAlloc;
 
 #[global_allocator]
 static PALLOC: PostAlloc = PostAlloc;
 
-static COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-// static ALLOC_REPORT: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
-
 unsafe impl GlobalAlloc for PostAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        // #[cfg(feature = "std")]
-        // {
-            // let mut buf = [0u8; 256];
-            // let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
-            // let mut msg = &mut buf;
-            // (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
-            // msg[255] = 0; // Guarantee null termination for the C writer.
-            // pg_sys::write_stderr(msg as *const _ as *const i8);
-        // }
-        if !pg_sys::CurrentMemoryContext.is_null() {
-            pg_sys::SPI_palloc(layout.size()).cast()
-        } else {
-            pg_sys::palloc(layout.size()).cast()
-        }
+        pg_sys::palloc(layout.size()).cast()
     }
 
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        // if let Ok(&mut txt) = ALLOC_REPORT.get_mut() {
-        // #[cfg(feature = "std")]
-        // {
-            // let mut buf = [0u8; 256];
-            // let counter = COUNTER.fetch_add(1, Ordering::AcqRel);
-            // let mut msg = &mut buf;
-            // (&mut msg[..]).write_fmt(format_args!("allocated/deallocated at least {counter} times."));
-            // msg[255] = 0; // Guarantee null termination for the C writer.
-            // pg_sys::write_stderr(msg as *const _ as *const i8);
-        // }
-        pg_sys::pfree(ptr.cast())
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        pg_sys::pfree(ptr.cast());
     }
 }

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,6 +1,6 @@
 use core::alloc::{GlobalAlloc, Layout};
 use core::sync::atomic::{AtomicUsize, Ordering};
-use std::io::Write;
+// use std::io::Write;
 use pgx::pg_sys::{self, SPI_palloc, pfree};
 use pgx::log;
 

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,5 +1,5 @@
 use core::alloc::{GlobalAlloc, Layout};
-use pgx::pg_sys::{SPI_palloc, SPI_repalloc, SPI_pfree};
+use pgx::pg_sys::{self, SPI_palloc, SPI_repalloc, SPI_pfree};
 use pgx::log;
 
 struct PostAlloc;
@@ -9,11 +9,13 @@ static PALLOC: PostAlloc = PostAlloc;
 
 unsafe impl GlobalAlloc for PostAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        log!("allocated using custom allocator!");
+        let msg = "attempt to emit alloc message from custom allocator";
+        pg_sys::write_stderr(msg as *const _ as *const i8);
         SPI_palloc(layout.size()).cast()
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        log!("deallocated using custom allocator!");
+        let msg = "attempt to emit dealloc message from custom allocator";
+        pg_sys::write_stderr(msg as *const _ as *const i8);
         SPI_pfree(ptr.cast())
     }
 }

--- a/src/postalloc.rs
+++ b/src/postalloc.rs
@@ -1,7 +1,8 @@
+extern crate std;
 use core::alloc::{GlobalAlloc, Layout};
 use core::sync::atomic::{AtomicUsize, Ordering};
-// use std::io::Write;
-use pgx::pg_sys::{self, SPI_palloc, SPI_pfree};
+use std::io::Write;
+use pgx::pg_sys::{self, SPI_palloc, pfree};
 use pgx::log;
 
 // SPI_palloc:
@@ -46,6 +47,6 @@ unsafe impl GlobalAlloc for PostAlloc {
             // msg[255] = 0; // Guarantee null termination for the C writer.
             // pg_sys::write_stderr(msg as *const _ as *const i8);
         // }
-        SPI_pfree(ptr.cast())
+        pfree(ptr.cast())
     }
 }


### PR DESCRIPTION
This doesn't include out-of-line crates I was fooling around with that are referenced here, as I wasn't sure what the best restructuring of things would be at the time, so I just pushed them somewhere else. At the moment I have just been using more direct FFI calls to Postgres for the allocator's implementation, but I imagine with some refactoring of PGX, a possible more sophisticated implementation might mesh itself more seamlessly with existing code in PGX. Or not.

One of the unresolved questions is "wait, why do tests randomly fail if I use `palloc` instead of `SPI_palloc`?"