### PR TITLE
Improved Error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,15 +745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,9 +764,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libloading"
@@ -950,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -993,33 +984,31 @@ checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "owo-colors"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1055,16 +1044,15 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c460dff28460a37f9b11ce656d83fadd2ecd8bae53b89f7d7be4ff3337cde969"
+checksum = "541daadd2b8b6bcbcca8772c03dcdec968f97ea54e0faca7b0299a8eec4e6869"
 dependencies = [
  "atomic-traits",
  "bitflags",
  "cstr_core",
  "enum-primitive-derive",
  "eyre",
- "hash32",
  "heapless",
  "num-traits",
  "once_cell",
@@ -1084,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930e43145e3cf6144ed71089e66f34c8d9e017f7f9c53d9e42ea15559916d473"
+checksum = "90af33a34d24228eedae09bd34f6c57a8f89dcc910bd5b6d08dac1c4816b17c3"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1097,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8252505bec328b016b7ce68319a17954c0858e31b442db28ca3d60602e394fa"
+checksum = "2b93a0a406092cd49372344542f1e04f009203c746060d76b9014cb144e7bbb8"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1119,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4828b4bed337a3adc4898f04bdde1a4185a8ec7a8af004be528a87918c920c"
+checksum = "e1c08b94a24472166ca4bb57ecf1ef3a6db37b25e58b5a9a3c3ade8b322fef36"
 dependencies = [
  "eyre",
  "libc",
@@ -1140,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c485e64d4c25cac2882c2ec0b42a0a090debdee1156f2ee796e56c8e03876d"
+checksum = "3b8719c1423a83062bd22670f9d9e2e7bb1cf2044c57e9b74986f421641f3841"
 dependencies = [
  "atty",
  "convert_case",
@@ -1218,19 +1206,24 @@ dependencies = [
 name = "plrust"
 version = "0.0.0"
 dependencies = [
+ "color-eyre",
+ "eyre",
  "libloading",
  "once_cell",
  "pgx",
  "pgx-tests",
  "tempdir",
+ "thiserror",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "postgres"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb76d6535496f633fa799bb872ffb4790e9cbdedda9d35564ca0252f930c0dd5"
+checksum = "c8bbcd5f6deb39585a0d9f4ef34c4a41c25b7ad26d23c75d837d78c8e7adc85f"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1242,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ec03bce71f18b4a27c4c64c6ba2ddf74686d69b91d8714fb32ead3adaed713"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -1260,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
+checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1277,9 +1270,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
+checksum = "d9e07e3a46d0771a8a06b5f4441527802830b43e679ba12f44960f48dd4c6803"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1626,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
@@ -1657,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1668,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1781,9 +1774,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1901,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c8b33df661b548dcd8f9bf87debb8c56c05657ed291122e1188698c2ece95"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1924,16 +1917,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2079,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom 0.2.6",
 ]
@@ -2178,6 +2171,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "thiserror",
  "toml",
  "tracing",
+ "tracing-error",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,16 @@ pg_test = []
 sandboxed = []
 
 [dependencies]
-pgx = "0.4.3"
+pgx = "0.4.4"
 libloading = "0.7.2"
+thiserror = "1.0"
+eyre = "0.6"
+color-eyre = "0.6"
+tracing = { version = "0.1", features = [ "valuable" ] }
+tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
 
 [dev-dependencies]
-pgx-tests = "0.4.0"
+pgx-tests = "0.4.4"
 tempdir = "0.3.7"
 once_cell = "1.7.2"
 toml = "0.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ eyre = "0.6"
 color-eyre = "0.6"
 tracing = { version = "0.1", features = [ "valuable" ] }
 tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+tracing-error = "0.2"
 
 [dev-dependencies]
 pgx-tests = "0.4.4"

--- a/flake.lock
+++ b/flake.lock
@@ -78,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639947939,
-        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "lastModified": 1651574473,
+        "narHash": "sha256-wQhFORvRjo8LB2hTmETmv6cbyKGDPbfWqvZ/0chnDE4=",
         "ref": "master",
-        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
-        "revCount": 282,
+        "rev": "f21309b38e1da0d61b881b6b6d41b81c1aed4e1d",
+        "revCount": 290,
         "type": "git",
         "url": "https://github.com/nix-community/naersk"
       },
@@ -93,11 +93,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646506091,
-        "narHash": "sha256-sWNAJE2m+HOh1jtXlHcnhxsj6/sXrHgbqVNcVRlveK4=",
+        "lastModified": 1652692103,
+        "narHash": "sha256-ygRLh8g0F/WkVCSfQcxMoVaaD45i6Ky+f+b4wCOazag=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e644bd62489b516292c816f70bf0052c693b3c7",
+        "rev": "556ce9a40abde33738e6c9eac65f965a8be3b623",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1647454589,
-        "narHash": "sha256-vqIXsOA7XSq+QedZ//JiabBw9/KluipSy87R4cfVKEc=",
+        "lastModified": 1652033309,
+        "narHash": "sha256-a8R1KhbwZvtXYKx0TeD8y+7gBJfpfKM5N5fhPalHj9s=",
         "ref": "master",
-        "rev": "a96c1b75380cfda210029bc4671b342c4e904fe7",
-        "revCount": 1056,
+        "rev": "52e40fbc88a99e7cdd23d940b43529fa1625b128",
+        "revCount": 1097,
         "type": "git",
         "url": "https://github.com/zombodb/pgx"
       },
@@ -169,11 +169,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646965545,
-        "narHash": "sha256-TnOdd6d+5QeF2JkCvpEi7JbRampCZXCBUraukJI743U=",
+        "lastModified": 1652668492,
+        "narHash": "sha256-IkkheO8APgbJp7XO5DbYb2MynTJs6smE9EvDjrWA488=",
         "ref": "master",
-        "rev": "f540e0001088700f72a3b2a178c9d8e70616a4a9",
-        "revCount": 545,
+        "rev": "ea19353ab585e3b35611368bad781aa3d10d973f",
+        "revCount": 612,
         "type": "git",
         "url": "https://github.com/oxalica/rust-overlay"
       },

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum PlRustError {
     LibLoading(#[from] libloading::Error),
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     #[error("Generation error (Mac OS x86_64 specific): {0}")]
-    Generation(#[from] crate::generation::Error),
+    Generation(#[from] crate::plrust::generation::Error),
     #[error("Creating crate directory in plrust.work_dir GUC location: {0}")]
     CrateDirectory(std::io::Error),
     #[error("Executing `cargo build`: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-
 #[derive(thiserror::Error, Debug)]
 pub enum PlRustError {
     #[error("Failed pg_sys::CheckFunctionValidatorAccess")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,25 @@
+
+#[derive(thiserror::Error, Debug)]
+pub enum PlRustError {
+    #[error("Failed pg_sys::CheckFunctionValidatorAccess")]
+    CheckFunctionValidatorAccess,
+    #[error("pgx::pg_sys::FunctionCallInfo was Null")]
+    NullFunctionCallInfo,
+    #[error("pgx::pg_sys::FmgrInfo was Null")]
+    NullFmgrInfo,
+    #[error("libloading error: {0}")]
+    LibLoading(#[from] libloading::Error),
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    #[error("Generation error (Mac OS x86_64 specific): {0}")]
+    Generation(#[from] crate::generation::Error),
+    #[error("Creating crate directory in plrust.work_dir GUC location: {0}")]
+    CrateDirectory(std::io::Error),
+    #[error("Executing `cargo build`: {0}")]
+    CargoBuildExec(std::io::Error),
+    #[error("`cargo build` failed: {0}")]
+    CargoBuildFail(String),
+    #[error("Produced shared object not found")]
+    SharedObjectNotFound,
+    #[error("Cargo output was not UTF-8: {0}")]
+    CargoOutputNotUtf8(std::string::FromUtf8Error)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,10 @@ pub enum PlRustError {
     NullFunctionCallInfo,
     #[error("pgx::pg_sys::FmgrInfo was Null")]
     NullFmgrInfo,
+    #[error("The Procedure Tuple was NULL")]
+    NullProcTuple,
+    #[error("The source code of the function was NULL")]
+    NullSourceCode,
     #[error("libloading error: {0}")]
     LibLoading(#[from] libloading::Error),
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
@@ -21,5 +25,15 @@ pub enum PlRustError {
     #[error("Produced shared object not found")]
     SharedObjectNotFound,
     #[error("Cargo output was not UTF-8: {0}")]
-    CargoOutputNotUtf8(std::string::FromUtf8Error)
+    CargoOutputNotUtf8(std::string::FromUtf8Error),
+    #[error("Creating source directory: {0}")]
+    CreatingSourceDirectory(std::io::Error),
+    #[error("Writing source code to `src/lib.rs`: {0}")]
+    WritingLibRs(std::io::Error),
+    #[error("Writing `Cargo.toml`: {0}")]
+    WritingCargoToml(std::io::Error),
+    #[error("Unsupported SQL type OID: {0}")]
+    UnsupportedSqlType(pgx::pg_sys::Oid),
+    #[error("Function `{0}` was not a PL/Rust function")]
+    NotPlRustFunction(pgx::pg_sys::Oid),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,8 @@ pub enum PlRustError {
     CrateDirectory(std::io::Error),
     #[error("Executing `cargo build`: {0}")]
     CargoBuildExec(std::io::Error),
-    #[error("`cargo build` failed: {0}")]
-    CargoBuildFail(String),
+    #[error("`cargo build` failed")]
+    CargoBuildFail,
     #[error("Produced shared object not found")]
     SharedObjectNotFound,
     #[error("Cargo output was not UTF-8: {0}")]

--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 
 static PLRUST_WORK_DIR: GucSetting<Option<&'static str>> = GucSetting::new(None);
 static PLRUST_PG_CONFIG: GucSetting<Option<&'static str>> = GucSetting::new(None);
+static PLRUST_TRACING_LEVEL: GucSetting<Option<&'static str>> = GucSetting::new(None);
 
 pub(crate) fn init() {
     GucRegistry::define_string_guc(
@@ -28,6 +29,14 @@ pub(crate) fn init() {
         "What is the full path to the `pg_config` tool for this Postgres installation?",
         "What is the full path to the `pg_config` tool for this Postgres installation?",
         &PLRUST_PG_CONFIG,
+        GucContext::Sighup,
+    );
+
+    GucRegistry::define_string_guc(
+        "plrust.tracing_level",
+        "The tracing level to use while running pl/rust",
+        "The tracing level to use while running pl/rust. Should be `error`, `warn`, `info`, `debug`, or `trace`",
+        &PLRUST_TRACING_LEVEL,
         GucContext::Sighup,
     );
 }
@@ -53,4 +62,11 @@ pub(crate) fn pg_config() -> String {
     PLRUST_PG_CONFIG
         .get()
         .expect("plrust.pg_config is not set in postgresql.conf")
+}
+
+pub(crate) fn tracing_level() -> tracing::Level {
+    PLRUST_TRACING_LEVEL
+        .get()
+        .map(|v| v.parse().expect("plrust.tracing_level was invalid"))
+        .unwrap_or(tracing::Level::INFO)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ fn _PG_init() {
 CREATE FUNCTION plrust_call_handler() RETURNS language_handler
     LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
 ")]
-#[tracing::instrument(level = "info")]
+#[tracing::instrument(level = "debug")]
 unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe fn plrust_call_handler_inner(
         fcinfo: pg_sys::FunctionCallInfo,
@@ -96,7 +96,7 @@ unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum
 }
 
 #[pg_extern]
-#[tracing::instrument(level = "info")]
+#[tracing::instrument(level = "debug")]
 unsafe fn plrust_validator(fn_oid: pg_sys::Oid, fcinfo: pg_sys::FunctionCallInfo) {
     unsafe fn plrust_validator_inner(
         fn_oid: pg_sys::Oid,
@@ -138,6 +138,7 @@ unsafe fn plrust_validator(fn_oid: pg_sys::Oid, fcinfo: pg_sys::FunctionCallInfo
 }
 
 #[pg_extern]
+#[tracing::instrument(level = "debug")]
 fn recompile_function(
     fn_oid: pg_sys::Oid,
 ) -> (
@@ -146,7 +147,6 @@ fn recompile_function(
     name!(stderr, Option<String>),
     name!(plrust_error, Option<String>),
 ) {
-    tracing::error!("Swoop de woop");
     unsafe {
         plrust::unload_function(fn_oid);
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,11 +23,7 @@ pub(crate) struct PgxLogWriter<const TRIM: bool = true>;
 impl<const TRIM: bool> Write for PgxLogWriter<TRIM> {
     fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
         let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
-        let content = if TRIM {
-            content.trim_start()
-        } else {
-            content
-        };
+        let content = if TRIM { content.trim_start() } else { content };
         pgx::elog(pgx::log::PgLogLevel::LOG, content);
         Ok(data.len())
     }
@@ -41,11 +37,7 @@ pub(crate) struct PgxNoticeWriter<const TRIM: bool = true>;
 impl<const TRIM: bool> Write for PgxNoticeWriter<TRIM> {
     fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
         let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
-        let content = if TRIM {
-            content.trim_start()
-        } else {
-            content
-        };
+        let content = if TRIM { content.trim_start() } else { content };
         pgx::elog(pgx::log::PgLogLevel::NOTICE, content);
         Ok(data.len())
     }
@@ -59,11 +51,7 @@ pub(crate) struct PgxWarningWriter<const TRIM: bool = true>;
 impl<const TRIM: bool> Write for PgxWarningWriter<TRIM> {
     fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
         let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
-        let content = if TRIM {
-            content.trim_start()
-        } else {
-            content
-        };
+        let content = if TRIM { content.trim_start() } else { content };
         pgx::elog(pgx::log::PgLogLevel::WARNING, content);
         Ok(data.len())
     }
@@ -71,4 +59,3 @@ impl<const TRIM: bool> Write for PgxWarningWriter<TRIM> {
         Ok(())
     }
 }
-

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,74 @@
+use std::io::Write;
+
+pub(crate) struct PgxGuestWriter<const IS_STDERR: bool>;
+
+impl<const IS_STDERR: bool> Write for PgxGuestWriter<IS_STDERR> {
+    fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
+        let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
+        let prefixed = if IS_STDERR {
+            String::from("stderr: ") + content
+        } else {
+            String::from("stdout: ") + content
+        };
+        pgx::elog(pgx::log::PgLogLevel::LOG, &prefixed);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+
+pub(crate) struct PgxLogWriter<const TRIM: bool = true>;
+
+impl<const TRIM: bool> Write for PgxLogWriter<TRIM> {
+    fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
+        let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
+        let content = if TRIM {
+            content.trim_start()
+        } else {
+            content
+        };
+        pgx::elog(pgx::log::PgLogLevel::LOG, content);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+
+pub(crate) struct PgxNoticeWriter<const TRIM: bool = true>;
+
+impl<const TRIM: bool> Write for PgxNoticeWriter<TRIM> {
+    fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
+        let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
+        let content = if TRIM {
+            content.trim_start()
+        } else {
+            content
+        };
+        pgx::elog(pgx::log::PgLogLevel::NOTICE, content);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+
+pub(crate) struct PgxWarningWriter<const TRIM: bool = true>;
+
+impl<const TRIM: bool> Write for PgxWarningWriter<TRIM> {
+    fn write(&mut self, data: &[u8]) -> std::result::Result<usize, std::io::Error> {
+        let content = std::str::from_utf8(data).expect("Could not interpret stdout as UTF-8");
+        let content = if TRIM {
+            content.trim_start()
+        } else {
+            content
+        };
+        pgx::elog(pgx::log::PgLogLevel::WARNING, content);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -37,7 +37,7 @@ pub(crate) fn init() {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-mod generation {
+pub(crate) mod generation {
     /*!
         Darwin x86_64 is a peculiar platform for `dlclose`, this exists for a workaround to support
         `CREATE OR REPLACE FUNCTION`.

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -37,7 +37,7 @@ pub(crate) fn init() {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-pub(crate) mod generation {
+pub mod generation {
     /*!
         Darwin x86_64 is a peculiar platform for `dlclose`, this exists for a workaround to support
         `CREATE OR REPLACE FUNCTION`.
@@ -62,7 +62,7 @@ pub(crate) mod generation {
     use std::fs;
 
     #[derive(thiserror::Error, Debug)]
-    pub(crate) enum Error {
+    pub enum Error {
         #[error("No generations found (Mac OS x86_64 specific)")]
         NoGenerations,
         #[error("std::io::Error: {0}")]

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -59,7 +59,7 @@ mod generation {
     !*/
 
     use super::*;
-    use std::{fs, io};
+    use std::fs;
 
     #[derive(thiserror::Error, Debug)]
     enum Error {

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -66,7 +66,7 @@ mod generation {
         #[error("No generations found (Mac OS x86_64 specific)")]
         NoGenerations,
         #[error("std::io::Error: {0}")]
-        StdIoError(std::io::Error),
+        StdIoError(#[from] std::io::Error),
     }
 
     /// Find existing generations of a given prefix.

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -62,7 +62,7 @@ pub(crate) mod generation {
     use std::fs;
 
     #[derive(thiserror::Error, Debug)]
-    enum Error {
+    pub(crate) enum Error {
         #[error("No generations found (Mac OS x86_64 specific)")]
         NoGenerations,
         #[error("std::io::Error: {0}")]


### PR DESCRIPTION
Improves error handling code in PL/Rust.

Includes:

* `thiserror`
* `eyre`/`tracing` wired up to not interfere with pgx
* Spantraces and error sections supported
* *Most* unwraps turned into errors, this is just a first pass.
* `tracing_level` GUC for customizing the log level of PL/Rust itself
* `#[pg_extern]` functions now wrap functions which return errors, and handle them.
* Updates flake for CI