### PR TITLE
Guarantee pgx and cargo-pgx version in ./build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 [[package]]
 name = "pgx"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#8d157d5a4355619b3d47d0fa5633699b4462d350"
+source = "git+https://github.com/tcdi/pgx?branch=develop#47225fc99bef92d1cbd0a0c2eb94215ed0525170"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "pgx-macros"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#8d157d5a4355619b3d47d0fa5633699b4462d350"
+source = "git+https://github.com/tcdi/pgx?branch=develop#47225fc99bef92d1cbd0a0c2eb94215ed0525170"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-sys"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#8d157d5a4355619b3d47d0fa5633699b4462d350"
+source = "git+https://github.com/tcdi/pgx?branch=develop#47225fc99bef92d1cbd0a0c2eb94215ed0525170"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "pgx-tests"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#8d157d5a4355619b3d47d0fa5633699b4462d350"
+source = "git+https://github.com/tcdi/pgx?branch=develop#47225fc99bef92d1cbd0a0c2eb94215ed0525170"
 dependencies = [
  "eyre",
  "libc",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "pgx-utils"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#8d157d5a4355619b3d47d0fa5633699b4462d350"
+source = "git+https://github.com/tcdi/pgx?branch=develop#47225fc99bef92d1cbd0a0c2eb94215ed0525170"
 dependencies = [
  "atty",
  "convert_case",

--- a/build
+++ b/build
@@ -5,6 +5,15 @@ if [ -z "$PLRUST_TARGET" ]; then
     export PLRUST_TARGET="x86_64-unknown-linux-postgres"
 fi
 
+# Make sure the tip of pgx's develop branch is used,
+# until a release that has all the necessary features is cut.
+cargo update -p pgx
+cargo fetch
+cargo install cargo-pgx --git "https://github.com/tcdi/pgx.git" --branch "develop"
+# Don't need to run cargo pgx init: user might already have set it up,
+# and doing so risks clobbering their configuration.
+# If they get an error, it's fairly self-explanatory.
+
 (
     if cd postgrestd; then
         git pull

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ cargo install cargo-pgx --git "https://github.com/tcdi/pgx.git" --branch "develo
         git pull
         git submodule update --init --recursive
     else
-        git clone https://github.com/tcdi/postgrestd.git --recurse-submodules --branch "cargo-lock"
+        git clone https://github.com/tcdi/postgrestd.git --recurse-submodules
         cd ./postgrestd
     fi
     cargo clean

--- a/build
+++ b/build
@@ -19,7 +19,7 @@ cargo install cargo-pgx --git "https://github.com/tcdi/pgx.git" --branch "develo
         git pull
         git submodule update --init --recursive
     else
-        git clone https://github.com/tcdi/postgrestd.git --recurse-submodules
+        git clone https://github.com/tcdi/postgrestd.git --recurse-submodules --branch "cargo-lock"
         cd ./postgrestd
     fi
     cargo clean


### PR DESCRIPTION
Most common user error recently has been pgx and cargo-pgx versions being misaligned.
Simply force them in the build script as a temporary solution until releases are cut.