### PR TITLE
Include db_oid when writing/referencing the binary on disk

### DIFF
--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -92,6 +92,8 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<(PathBuf, Ou
     let work_dir = gucs::work_dir();
     let pg_config = gucs::pg_config();
     let target_dir = work_dir.join("target");
+    // SAFETY: Postgres globally sets this to `const InvalidOid`, so is always read-safe,
+    // then writes it only during initialization, so we should not be racing anyone.
     let db_oid = unsafe { MyDatabaseId };
 
     let generated = unsafe { UserCrate::try_from_fn_oid(db_oid, fn_oid)? };

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -254,7 +254,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use pgx::*;
+                use ::pgx::*;
                 #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())

--- a/src/user_crate/state_built.rs
+++ b/src/user_crate/state_built.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 #[must_use]
 pub(crate) struct StateBuilt {
+    db_oid: pg_sys::Oid,
     fn_oid: pg_sys::Oid,
     shared_object: PathBuf,
 }
@@ -12,8 +13,9 @@ impl CrateState for StateBuilt {}
 
 impl StateBuilt {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn new(fn_oid: pg_sys::Oid, shared_object: PathBuf) -> Self {
+    pub(crate) fn new(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid, shared_object: PathBuf) -> Self {
         Self {
+            db_oid,
             fn_oid,
             shared_object,
         }
@@ -27,8 +29,12 @@ impl StateBuilt {
         &self.fn_oid
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(fn_oid = %self.fn_oid, shared_object = %self.shared_object.display()))]
+    pub(crate) fn db_oid(&self) -> &u32 {
+        &self.db_oid
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid, shared_object = %self.shared_object.display()))]
     pub(crate) unsafe fn load(self) -> eyre::Result<StateLoaded> {
-        StateLoaded::load(self.fn_oid, self.shared_object)
+        StateLoaded::load(self.db_oid, self.fn_oid, self.shared_object)
     }
 }

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -134,7 +134,7 @@ impl StateGenerated {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
     pub(crate) fn lib_rs(&self) -> eyre::Result<syn::File> {
         let mut skeleton: syn::File = syn::parse_quote!(
-            use pgx::*;
+            use ::pgx::*;
         );
 
         let crate_name = self.crate_name();
@@ -382,7 +382,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use pgx::*;
+                use ::pgx::*;
                 #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())
@@ -439,7 +439,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use pgx::*;
+                use ::pgx::*;
                 #[pg_extern]
                 fn #symbol_ident(val: Option<i32>) -> Option<i64> {
                     val.map(|v| v as i64)
@@ -496,7 +496,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use pgx::*;
+                use ::pgx::*;
                 #[pg_extern]
                 fn #symbol_ident(val: &str) -> Option<impl Iterator<Item = Option<String>> + '_> {
                     Some(std::iter::repeat(val).take(5))
@@ -544,7 +544,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use pgx::*;
+                use ::pgx::*;
                 #[pg_trigger]
                 fn #symbol_ident(
                     trigger: &::pgx::PgTrigger,


### PR DESCRIPTION
FunctionOids are unique within the database but not across it. It's possible for two PL/Rust functions to share the same fn_oid across different databases leading to overwriting the same function, or accessing it.

To prevent this include db_oid when constructing the name to guarantee uniqueness of the files

Note this might be unnecessary by the time https://github.com/tcdi/plrust/issues/28 is addressed but until then it seems like it'd be better to avoid this potential case.