### PR TITLE
Include architecture in name of plrust compiled objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ force_enable_x86_64_darwin_generations = []
 target_postgrestd = []
 
 [dependencies]
+current_platform = "0.2.0"
 cfg-if = "1"
 pgx = { version = "0.5.0-beta.0" }
 pgx-pg-config = { version = "0.5.0-beta.0" }

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -21,6 +21,8 @@ use std::{
     process::Output,
 };
 
+use current_platform::CURRENT_PLATFORM;
+
 thread_local! {
     pub(crate) static LOADED_SYMBOLS: RefCell<HashMap<pg_sys::Oid, UserCrate<StateLoaded>>> = Default::default();
 }
@@ -106,7 +108,15 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<(PathBuf, Ou
 }
 
 pub(crate) fn crate_name(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid) -> String {
-    let crate_name = format!("plrust_fn_oid_{}_{}", db_oid, fn_oid);
+    // Include current_platform in the name
+    // There's no guarantee that the compiled library will be
+    // in the same architecture if the database was restored
+    let crate_name = format!(
+        "plrust_fn_oid_{}_{}_{}",
+        db_oid,
+        fn_oid,
+        CURRENT_PLATFORM.replace("-", "_")
+    );
 
     crate_name
 }


### PR DESCRIPTION
There's no guarantee that when the database is restored it'll land on the same host architecture as when the object was compiled.

This lays the ground work to at least avoid running the object in question

We replace '-' in the host triple with '_' because it's not recognized as a valid identifier