### PR TITLE
Fixes broken tests due to introduction of pgx::prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "pgx"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#3894728ab8ed732a3087a72363f32ebe0ddd7c8b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "pgx-macros"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#3894728ab8ed732a3087a72363f32ebe0ddd7c8b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-config"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#3894728ab8ed732a3087a72363f32ebe0ddd7c8b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
 dependencies = [
  "dirs",
  "eyre",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-sys"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#3894728ab8ed732a3087a72363f32ebe0ddd7c8b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "pgx-tests"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#3894728ab8ed732a3087a72363f32ebe0ddd7c8b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
 dependencies = [
  "eyre",
  "libc",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "pgx-utils"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#3894728ab8ed732a3087a72363f32ebe0ddd7c8b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
 dependencies = [
  "atty",
  "convert_case",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -107,6 +107,7 @@ mod tests {
                 STRICT
                 LANGUAGE PLRUST AS
             $$
+                use pgx::IntoDatum;
                 let id = Spi::get_one_with_args(
                     "SELECT id FROM contributors_pets WHERE name = $1",
                     vec![(PgBuiltInOids::TEXTOID.oid(), name.into_datum())],

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -254,7 +254,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use ::pgx::*;
+                use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -137,7 +137,7 @@ impl StateGenerated {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
     pub(crate) fn lib_rs(&self) -> eyre::Result<syn::File> {
         let mut skeleton: syn::File = syn::parse_quote!(
-            use ::pgx::*;
+            use pgx::prelude::*;
         );
 
         let crate_name = self.crate_name();
@@ -385,7 +385,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use ::pgx::*;
+                use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())
@@ -442,7 +442,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use ::pgx::*;
+                use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(val: Option<i32>) -> Option<i64> {
                     val.map(|v| v as i64)
@@ -499,7 +499,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use ::pgx::*;
+                use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(val: &str) -> Option<::pgx::iter::SetOfIterator<Option<String>>> {
                     Some(std::iter::repeat(val).take(5))
@@ -547,7 +547,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                use ::pgx::*;
+                use pgx::prelude::*;
                 #[pg_trigger]
                 fn #symbol_ident(
                     trigger: &::pgx::PgTrigger,


### PR DESCRIPTION
It was noticed that a few plrust tests were broken after PGX introduced `pgx::prelude`. See here https://github.com/tcdi/pgx/pull/699

The work here aims to fix those tests.