### PR TITLE
Adds .vscode workdir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ sql/*.generated.sql
 .direnv
 scratch
 postgrestd/
+.vscode/
+


### PR DESCRIPTION
For those of us that use VSCode, it's probably advisable to add this to `.gitignore`.