### PR TITLE
Fix Rust highlighting for cargo expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ cargo pgx init --pg14 download
 Then, add some configuration to the `postgresql.conf` and ensure there is a
 writable `work_dir`:
 
+<!-- If `cargo expand` (a very useful tool for debugging pgx-macros) is used to the plrust crate,
+    it embeds the README.md in a block doc comment: /** */. To preserve correct Rust highlighting,
+    balance the upcoming bash glob with a comment-open: /* -->
 ```bash
 PG_CONFIG=$(find ~/.pgx/14.*/pgx-install/bin/pg_config)
 SCRATCH_DIR=/home/${USER}/git/zombodb/plrust/scratch


### PR DESCRIPTION
If cargo expand is used on plrust, it embeds the README.md in the expansion inside a block doc-comment. A Rust syntax highlighter will thus interpret the bash in the README.md as Rust. This means some forms of glob syntax are seen as ending the comment instead.

The result is that everything has broken highlighting, and if we ever wanted to actually include the README.md, it might even break compilation!

Fortunately, Rust defines /* */ to have balanced nesting rules. Thus, putting a Rust block-comment-open inside an HTML comment, which is invisible when the README.markdown is viewed as HTML, fixes this for Rust syntax handlers that don't also know Markdown.