### PR TITLE
Add prototype unsafe checks in PL/Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
     - name: Run PL/Rust tests
       run: |
         cargo test --features "pg$PG_VER" --no-default-features --lib user_crate
-        cargo test --features "pg$PG_VER" --no-default-features --lib plrust
+        cargo test --features "pg$PG_VER verify" --no-default-features --lib plrust
 
     - name: Run PL/Rust + postgrestd tests
       if: matrix.os == 'ubuntu-20.04' && matrix.version == 'postgres-14'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cargo-geiger-serde"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63fcf425f40a413b6b1052486b48ce4cc7cfa407a335790ba2992a2571cf2a17"
+dependencies = [
+ "semver 1.0.10",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +409,12 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "current_platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
 
 [[package]]
 name = "digest"
@@ -603,6 +620,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "geiger"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe24f2b38bd325f6030942529c5e2c788511ce908b9d459000a0eb3d93960b4d"
+dependencies = [
+ "cargo-geiger-serde",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -973,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "pgx"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
+source = "git+https://github.com/tcdi/pgx?branch=develop#ba28e5e2940257e4b15ed91434e52a50b40d4d91"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1002,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "pgx-macros"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
+source = "git+https://github.com/tcdi/pgx?branch=develop#ba28e5e2940257e4b15ed91434e52a50b40d4d91"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1014,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-config"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
+source = "git+https://github.com/tcdi/pgx?branch=develop#ba28e5e2940257e4b15ed91434e52a50b40d4d91"
 dependencies = [
  "dirs",
  "eyre",
@@ -1030,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "pgx-pg-sys"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
+source = "git+https://github.com/tcdi/pgx?branch=develop#ba28e5e2940257e4b15ed91434e52a50b40d4d91"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1054,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "pgx-tests"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
+source = "git+https://github.com/tcdi/pgx?branch=develop#ba28e5e2940257e4b15ed91434e52a50b40d4d91"
 dependencies = [
  "eyre",
  "libc",
@@ -1076,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "pgx-utils"
 version = "0.5.0-beta.0"
-source = "git+https://github.com/tcdi/pgx?branch=develop#b48c8db02f1f93ec7d663c9921c5e408586f9de0"
+source = "git+https://github.com/tcdi/pgx?branch=develop#ba28e5e2940257e4b15ed91434e52a50b40d4d91"
 dependencies = [
  "atty",
  "convert_case",
@@ -1149,7 +1177,9 @@ version = "0.0.0"
 dependencies = [
  "cfg-if",
  "color-eyre",
+ "current_platform",
  "eyre",
+ "geiger",
  "libloading",
  "once_cell",
  "pgx",
@@ -1518,6 +1548,9 @@ name = "semver"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -1973,6 +2006,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/zombodb/plrust/"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg14"]
+default = ["pg14", "verify"]
 pg10 = ["pgx/pg10", "pgx-tests/pg10"]
 pg11 = ["pgx/pg11", "pgx-tests/pg11"]
 pg12 = ["pgx/pg12", "pgx-tests/pg12"]
@@ -24,6 +24,7 @@ sandboxed = []
 # Forcibly enable a feature used by x86_64 MacOS machines because they're bad at `dlclose()`
 force_enable_x86_64_darwin_generations = []
 target_postgrestd = []
+verify = ["dep:geiger"]
 
 [dependencies]
 current_platform = "0.2.0"
@@ -44,6 +45,8 @@ prettyplease = "0.1"
 toml = "0.5"
 tempdir = "0.3.7"
 once_cell = "1.7.2"
+
+geiger = { version = "0.4", optional = true } # unsafe detection
 
 [dev-dependencies]
 pgx-tests = "0.5.0-beta.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod user_crate;
 pub mod tests;
 
 use error::PlRustError;
-use pgx::{prelude::*, pg_getarg};
+use pgx::{pg_getarg, prelude::*};
 
 #[cfg(any(test, feature = "pg_test"))]
 pub use tests::pg_test;

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -137,6 +137,7 @@ impl StateGenerated {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
     pub(crate) fn lib_rs(&self) -> eyre::Result<syn::File> {
         let mut skeleton: syn::File = syn::parse_quote!(
+            #![deny(unsafe_op_in_unsafe_fn)]
             use pgx::prelude::*;
         );
 
@@ -385,6 +386,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
+                #![deny(unsafe_op_in_unsafe_fn)]
                 use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
@@ -442,6 +444,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
+                #![deny(unsafe_op_in_unsafe_fn)]
                 use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(val: Option<i32>) -> Option<i64> {
@@ -499,6 +502,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
+                #![deny(unsafe_op_in_unsafe_fn)]
                 use pgx::prelude::*;
                 #[pg_extern]
                 fn #symbol_ident(val: &str) -> Option<::pgx::iter::SetOfIterator<Option<String>>> {
@@ -547,6 +551,7 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
+                #![deny(unsafe_op_in_unsafe_fn)]
                 use pgx::prelude::*;
                 #[pg_trigger]
                 fn #symbol_ident(


### PR DESCRIPTION
This adds a new feature, `"verify"`, to PL/Rust, which is set by default at compilation time. It also makes all code written for PL/Rust more strict, opting in to RFC 2585's `unsafe_op_in_unsafe_fn` lint by default, to make it harder to escape `unsafe` detection with or without the `"verify"` feature. This is possible due to tcdi/pgx#707.

Together these are expected to take care of most ways of sneaking `unsafe` into a PL/Rust function, however this basic prototype does not handle a number of possible routes for recursion, crate dependencies, et cetera.