### PR TITLE
Use `Vec<syn::FnArg>` for deterministic arg order 

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -569,6 +569,38 @@ mod tests {
         assert_eq!(Some(2), result_2); // may get: Some(1)
         assert_eq!(Some(1), result_1); // may get: Some(2)
     }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic]
+    fn plrust_dup_args() {
+        let definition = r#"
+            CREATE FUNCTION not_unique(a int, a int)
+            RETURNS int AS
+            $$
+                a
+            $$ LANGUAGE plrust;
+        "#;
+        Spi::run(definition);
+        let result = Spi::get_one::<i32>("SELECT not_unique(1, 2);\n");
+        assert_eq!(Some(1), result);
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic]
+    fn plrust_defaulting_dup_args() {
+        let definition = r#"
+            CREATE FUNCTION not_unique(int, arg0 int)
+            RETURNS int AS
+            $$
+                arg0
+            $$ LANGUAGE plrust;
+        "#;
+        Spi::run(definition);
+        let result = Spi::get_one::<i32>("SELECT not_unique(1, 2);\n");
+        assert_eq!(Some(1), result);
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -419,7 +419,6 @@ mod tests {
         Spi::run(definition);
     }
 
-
     #[pg_test]
     #[search_path(@extschema@)]
     #[should_panic]
@@ -479,7 +478,7 @@ mod tests {
     #[search_path(@extschema@)]
     fn plrust_call_1st() {
         let definition = r#"
-            CREATE OR REPLACE FUNCTION ret_1st(a int, b int)
+            CREATE FUNCTION ret_1st(a int, b int)
             RETURNS int AS
             $$
                 a
@@ -494,7 +493,7 @@ mod tests {
     #[search_path(@extschema@)]
     fn plrust_call_2nd() {
         let definition = r#"
-            CREATE OR REPLACE FUNCTION ret_2nd(a int, b int)
+            CREATE FUNCTION ret_2nd(a int, b int)
             RETURNS int AS
             $$
                 b
@@ -509,7 +508,7 @@ mod tests {
     #[search_path(@extschema@)]
     fn plrust_call_me() {
         let definition = r#"
-            CREATE OR REPLACE FUNCTION pick_ret(a int, b int, pick int)
+            CREATE FUNCTION pick_ret(a int, b int, pick int)
             RETURNS int AS
             $$
                 match pick {
@@ -534,19 +533,19 @@ mod tests {
     #[search_path(@extschema@)]
     fn plrust_call_me_call_me() {
         let definition = r#"
-            CREATE OR REPLACE FUNCTION ret_1st(a int, b int)
+            CREATE FUNCTION ret_1st(a int, b int)
             RETURNS int AS
             $$
                 a
             $$ LANGUAGE plrust;
 
-            CREATE OR REPLACE FUNCTION ret_2nd(a int, b int)
+            CREATE FUNCTION ret_2nd(a int, b int)
             RETURNS int AS
             $$
                 b
             $$ LANGUAGE plrust;
 
-            CREATE OR REPLACE FUNCTION pick_ret(a int, b int, pick int)
+            CREATE FUNCTION pick_ret(a int, b int, pick int)
             RETURNS int AS
             $$
                 match pick {
@@ -559,17 +558,16 @@ mod tests {
         Spi::run(definition);
         let result_1 = Spi::get_one::<i32>("SELECT ret_1st(1, 2);\n");
         let result_2 = Spi::get_one::<i32>("SELECT ret_2nd(1, 2);\n");
-        assert_eq!(Some(1), result_1); // may get: Some(2)
-        assert_eq!(Some(2), result_2); // may get: Some(1)
-
         let result_a = Spi::get_one::<i32>("SELECT pick_ret(3, 4, 0);");
         let result_b = Spi::get_one::<i32>("SELECT pick_ret(5, 6, 1);");
         let result_c = Spi::get_one::<i32>("SELECT pick_ret(7, 8, 2);");
         let result_z = Spi::get_one::<i32>("SELECT pick_ret(9, 99, -1);");
-        assert_eq!(Some(3), result_a); // may get: Some(4) or None
-        assert_eq!(Some(6), result_b); // may get: None
-        assert_eq!(None, result_c);
         assert_eq!(None, result_z);
+        assert_eq!(None, result_c);
+        assert_eq!(Some(6), result_b); // may get: None
+        assert_eq!(Some(3), result_a); // may get: Some(4) or None
+        assert_eq!(Some(2), result_2); // may get: Some(1)
+        assert_eq!(Some(1), result_1); // may get: Some(2)
     }
 }
 

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -161,7 +161,6 @@ impl StateGenerated {
                 ref return_type,
                 ..
             } => {
-                let arguments = arguments.values();
                 let user_fn: syn::ItemFn = syn::parse2(quote! {
                     #[pg_extern]
                     fn #symbol_ident(


### PR DESCRIPTION
`HashMap<K, V, S>`, like most hash-keyed collection types,
does not order entries deliberately, instead simply hashing keys.
Unlike most hashed types, `HashMap<K, V, S = RandomState>` defaults
to using SipHash with a random seed to its hashing logic, which
can result in an essentially nondeterministic order in the map.
Even more peculiarly, `HashMap<K, V, RandomState>` iterates randomly,
because it does not use the key's ordering to iterate, but
simply starts at one entry and loops "in order" (i.e. random order).

By collecting arguments into a `HashMap`, then unpacking that map,
they were given a different ordinal position. This resulted in
calling with different orderings of arguments, as the arguments
only acquire names inside the Rust `fn` body: before that they
have only a number and a calling convention in the `extern "C"` ABI.
The `HashMap` is fruitless as we don't bother with the keys, so:
simply use a `Vec` of values to assure a consistent order.

This fixes #111.