### PR TITLE
Add boolean guc to enable auto-recompile upon missing so file (resolves #113)

### DIFF
--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 static PLRUST_WORK_DIR: GucSetting<Option<&'static str>> = GucSetting::new(None);
 static PLRUST_PG_CONFIG: GucSetting<Option<&'static str>> = GucSetting::new(None);
 static PLRUST_TRACING_LEVEL: GucSetting<Option<&'static str>> = GucSetting::new(None);
+static PLRUST_AUTO_RECOMPILE: GucSetting<bool> = GucSetting::new(false);
 
 pub(crate) fn init() {
     GucRegistry::define_string_guc(
@@ -39,6 +40,14 @@ pub(crate) fn init() {
         &PLRUST_TRACING_LEVEL,
         GucContext::Sighup,
     );
+
+    GucRegistry::define_bool_guc(
+        "plrust.auto_recompile",
+        "Recompile function if unable to find shared object file in plrust.work_dir",
+        "Recompile function if unable to find shared object file in plrust.work_dir",
+        &PLRUST_AUTO_RECOMPILE,
+        GucContext::Sighup,
+    )
 }
 
 pub(crate) fn work_dir() -> PathBuf {
@@ -64,4 +73,8 @@ pub(crate) fn tracing_level() -> tracing::Level {
         .get()
         .map(|v| v.parse().expect("plrust.tracing_level was invalid"))
         .unwrap_or(tracing::Level::INFO)
+}
+
+pub(crate) fn auto_recompile() -> bool {
+    PLRUST_AUTO_RECOMPILE.get()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum
         }
         .ok_or(PlRustError::NullFmgrInfo)?
         .fn_oid;
+        unsafe { plrust::recompile_missing_shared_object(fn_oid)?; }
         let retval = unsafe { plrust::evaluate_function(fn_oid, fcinfo)? };
         Ok(retval)
     }


### PR DESCRIPTION
## Issue - https://github.com/tcdi/plrust/issues/113

This commit adds a boolean guc which controls whether plrust will recompile missing .so files automatically when it is not found in plrust.workdir. By default it is set to false, but it can be updated dynamically.

By default
```
postgres=# show plrust.auto_recompile;
-[ RECORD 1 ]---------+----
plrust.auto_recompile | off
```

Remove the .so file for a function in `plrust.work_dir`, calling the function will then fail
```
postgres=# select foo(1);
ERROR:
   0: /home/antholeu/bc/plrust_workdir/plrust_fn_oid_13949_16396_x86_64_unknown_linux_gnu.so: cannot open shared object file: No such file or directory

Location:
   src/user_crate/state_loaded.rs:30

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
CONTEXT:  src/lib.rs:105:21
postgres=#
```

Set plrust.auto_recompile to true
```
postgres=# show plrust.auto_recompile;
-[ RECORD 1 ]---------+---
plrust.auto_recompile | on
```

Invoke the function
```
postgres=# select foo(1);
-[ RECORD 1 ]
foo | 1
```