### PR TITLE
Map `NUMERIC` to pgx 0.6's `AnyNumeric`

### DIFF
--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -153,7 +153,7 @@ pub(crate) fn oid_to_syn_type(type_oid: &PgOid, owned: bool) -> Result<syn::Type
             PgBuiltInOids::INT8OID => quote! { i64 },
             PgBuiltInOids::JSONBOID => quote! { JsonB },
             PgBuiltInOids::JSONOID => quote! { Json },
-            PgBuiltInOids::NUMERICOID => quote! { Numeric },
+            PgBuiltInOids::NUMERICOID => quote! { AnyNumeric },
             PgBuiltInOids::OIDOID => quote! { pg_sys::Oid },
             PgBuiltInOids::TEXTOID if owned => quote! { String },
             PgBuiltInOids::TEXTOID if !owned => quote! { &str },


### PR DESCRIPTION
We can't map to a specific `Numeric<P, S>` as Postgres doesn't store the "typmod" values in the `pg_proc` catalog, so by the time we create the function, those are lost to us.

I don't view this as a big deal, tho.  Users can use `AnyNumeric::rescale<P, S>().into()` to return a `AnyNumeric` that's been truncated/expanded to a particular precision and scale.  Alternatively, it can be handled at the SQL level, which I suspect is what most people do today with languages like plpgsql.

NOTE:  This PR will require a version of pgx > 0.5.6.