### PR TITLE
Move the ultimate storage of a plrust compiled function from disk to a table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +636,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1047,6 +1065,7 @@ dependencies = [
  "quote",
  "syn",
  "tempdir",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",
@@ -1572,6 +1591,20 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ libloading = "0.7.2"
 toml = "0.5"
 tempdir = "0.3.7" # for building crates
 current_platform = "0.2.0" # uses a build.rs
+tempfile = "3.3.0"
 
 # error handling, tracing, formatting
 thiserror = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,4 +34,6 @@ pub(crate) enum PlRustError {
     ParsingCodeBlock(syn::Error),
     #[error("Parsing error at span `{:?}`", .0.span())]
     Parse(#[from] syn::Error),
+    #[error("No plrust.plrust_proc entry for ({0}, {1}, {2}")]
+    NoProcEntry(pgx::pg_sys::Oid, &'static str, &'static str),
 }

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -8,7 +8,7 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 */
 
 use crate::{
-    gucs,
+    gucs, plrust_proc,
     user_crate::{StateLoaded, UserCrate},
 };
 
@@ -16,8 +16,6 @@ use pgx::{pg_sys::FunctionCallInfo, pg_sys::MyDatabaseId, prelude::*};
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, HashMap},
-    env::consts::DLL_SUFFIX,
-    path::PathBuf,
     process::Output,
 };
 
@@ -51,34 +49,13 @@ pub(crate) unsafe fn evaluate_function(
 ) -> eyre::Result<pg_sys::Datum> {
     LOADED_SYMBOLS.with(|loaded_symbols| {
         let mut loaded_symbols_handle = loaded_symbols.borrow_mut();
-        // SAFETY: Postgres globally sets this to `const InvalidOid`, so is always read-safe,
-        // then writes it only during initialization, so we should not be racing anyone.
-        let db_oid = unsafe { MyDatabaseId };
         let user_crate_loaded = match loaded_symbols_handle.entry(fn_oid) {
             entry @ Entry::Occupied(_) => {
                 entry.or_insert_with(|| unreachable!("Occupied entry was vacant"))
             }
             entry @ Entry::Vacant(_) => {
-                let crate_name = crate_name(db_oid, fn_oid);
-                let mut shared_object_name = crate_name;
-                #[cfg(any(
-                    all(target_os = "macos", target_arch = "x86_64"),
-                    feature = "force_enable_x86_64_darwin_generations"
-                ))]
-                {
-                    let (latest, _path) =
-                        crate::generation::latest_generation(&shared_object_name, true)
-                            .unwrap_or_default();
-
-                    shared_object_name.push_str(&format!("_{}", latest));
-                };
-                shared_object_name.push_str(DLL_SUFFIX);
-
-                let shared_library = gucs::work_dir().join(&shared_object_name);
-                let user_crate_built = UserCrate::built(db_oid, fn_oid, shared_library);
-                let user_crate_loaded = unsafe { user_crate_built.load()? };
-
-                entry.or_insert(user_crate_loaded)
+                let loaded = plrust_proc::load(fn_oid)?;
+                entry.or_insert(loaded)
             }
         };
 
@@ -92,8 +69,8 @@ pub(crate) unsafe fn evaluate_function(
     })
 }
 
-#[tracing::instrument(level = "debug")]
-pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<(PathBuf, Output)> {
+// #[tracing::instrument(level = "debug")]
+pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let work_dir = gucs::work_dir();
     let pg_config = gucs::pg_config();
     let target_dir = work_dir.join("target");
@@ -103,11 +80,20 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<(PathBuf, Ou
 
     let generated = unsafe { UserCrate::try_from_fn_oid(db_oid, fn_oid)? };
     let provisioned = generated.provision(&work_dir)?;
-    let (built, output) = provisioned.build(&work_dir, pg_config, Some(target_dir.as_path()))?;
-
+    let crate_dir = provisioned.crate_dir().to_path_buf();
+    let (built, output) = provisioned.build(pg_config, target_dir.as_path())?;
     let shared_object = built.shared_object();
 
-    Ok((shared_object.into(), output))
+    // store the shared object in our table
+    plrust_proc::insert(fn_oid, shared_object)?;
+
+    // cleanup after ourselves
+    tracing::trace!("removing {}", shared_object.display());
+    std::fs::remove_file(shared_object)?;
+    tracing::trace!("removing {}", crate_dir.display());
+    std::fs::remove_dir_all(crate_dir)?;
+
+    Ok(output)
 }
 
 pub(crate) fn crate_name(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid) -> String {

--- a/src/plrust_proc.rs
+++ b/src/plrust_proc.rs
@@ -1,0 +1,99 @@
+//! Routines for managing the `plrust.plrust_proc` extension table along with the data it contains
+use crate::error::PlRustError;
+use crate::gucs;
+use crate::user_crate::{StateLoaded, UserCrate};
+use pgx::pg_sys::MyDatabaseId;
+use pgx::{extension_sql, pg_sys, IntoDatum, PgBuiltInOids, PgOid, Spi};
+use std::path::Path;
+
+extension_sql!(
+    r#"
+CREATE TYPE supported_arch AS ENUM (
+    'aarch64',
+    'x86_64'
+);
+CREATE TABLE plrust_proc (
+    id   regproc            NOT NULL,
+    arch supported_arch     NOT NULL,
+    os   text               NOT NULL,
+    so   bytea              NOT NULL,
+    PRIMARY KEY(id, arch, os)
+    --
+    -- Would be nice if we could make a foreign key over to pg_catalog.pg_proc
+    -- but that's okay.  We'll be managing access to this table ourselves
+    --
+    -- CONSTRAINT ft_pg_proc_oid FOREIGN KEY(id) REFERENCES pg_catalog.pg_proc(oid)
+);
+SELECT pg_catalog.pg_extension_config_dump('plrust_proc', '');
+
+"#,
+    name = "extschema"
+);
+
+/// Insert a new row into the `plrust.plrust_proc` table to represent the shared library at the
+/// specified `so_path`.  This function intuits the `arch` and `os` values from the current runtime
+#[tracing::instrument(level = "debug")]
+pub(crate) fn insert(pg_proc_oid: pg_sys::Oid, so_path: &Path) -> eyre::Result<()> {
+    let so = std::fs::read(so_path)?;
+    let mut args = pkey_datums(pg_proc_oid);
+    args.push((PgBuiltInOids::BYTEAOID.oid(), so.into_datum()));
+
+    Spi::run_with_args(
+            "INSERT INTO plrust.plrust_proc(id, arch, os, so) VALUES ($1, $2::plrust.supported_arch, $3, $4)",
+            Some(args),
+        );
+    Ok(())
+}
+
+/// Dynamically load the shared library stored in `plrust.plrust_proc` for the specified `pg_proc_oid`
+/// procedure object id.  The function intuits the `arch` and `os` values from the current runtime
+#[tracing::instrument(level = "debug")]
+pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoaded>> {
+    // using SPI, read the plrust_proc entry for the provided pg_proc.oid value
+    let so = Spi::get_one_with_args::<&[u8]>(
+        "SELECT so FROM plrust.plrust_proc WHERE (id, arch, os) = ($1, $2::plrust.supported_arch, $3)",
+        pkey_datums(pg_proc_oid),
+        )
+        .ok_or(PlRustError::NoProcEntry(
+            pg_proc_oid,
+            std::env::consts::ARCH,
+            std::env::consts::OS,
+        ))?;
+
+    // we write the shared object (`so`) bytes out to a temporary file rooted in our
+    // configured `plrust.work_dir`.  This will get removed from disk when this function
+    // exists, which is fine because we'll have dlopen()'d it by then and no longer need it
+    let work_dir = gucs::work_dir();
+    let temp_so_file = tempfile::Builder::new().tempfile_in(work_dir)?;
+    std::fs::write(&temp_so_file, so)?;
+
+    // SAFETY: Postgres globally sets this to `const InvalidOid`, so is always read-safe,
+    // then writes it only during initialization, so we should not be racing anyone.
+    let db_oid = unsafe { MyDatabaseId };
+
+    // fabricate a StateBuilt version of the UserCrate so that we can "load()" it -- tho we're
+    // long since past the idea of crates, but whatev, I just work here
+    let built = UserCrate::built(db_oid, pg_proc_oid, temp_so_file.path());
+    let loaded = unsafe { built.load()? };
+
+    // just to be clear, the temp_so_file gets deleted here -- it does not stick around after
+    // we've dlopen()'d it
+    drop(temp_so_file);
+
+    // all good
+    Ok(loaded)
+}
+
+fn pkey_datums(pg_proc_oid: pg_sys::Oid) -> Vec<(PgOid, Option<pg_sys::Datum>)> {
+    vec![
+        (PgBuiltInOids::REGPROCOID.oid(), pg_proc_oid.into_datum()),
+        (
+            PgBuiltInOids::TEXTOID.oid(),
+            std::env::consts::ARCH.into_datum(),
+        ),
+        (
+            PgBuiltInOids::TEXTOID.oid(),
+            std::env::consts::OS.into_datum(),
+        ),
+    ]
+}

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -315,9 +315,9 @@ mod tests {
                 "Generated `Cargo.toml` differs from test (after formatting)",
             );
 
-            let provisioned = generated.provision(parent_dir.path())?;
+            let provisioned = generated.provision(&target_dir)?;
 
-            let (built, _output) = provisioned.build(pg_config, target_dir.as_path())?;
+            let (built, _output) = provisioned.build(pg_config, &target_dir)?;
 
             let _shared_object = built.shared_object();
 


### PR DESCRIPTION
The compilation process now cleans up after itself (we no longer leave any function-specific artifacts on disk, other than the shared `${PLRUST.WORK_DIR}target/` directory), and the .so bytes are inserted into the new `plrust.plrust_proc` table, tagged with the host's "arch" and "os", as the compiled pl/rust extension understands them.

There's more work to do around CREATE **OR REPLACE** FUNCTION, ALTER FUNCTION, and DROP FUNCTION, and likely some decisions to be changed, but putting this up for review and merge as it's otherwise compatible in functionality with what we have now.

