### PR TITLE
Store compiled shared object files in a new extension table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +636,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1047,6 +1065,7 @@ dependencies = [
  "quote",
  "syn",
  "tempdir",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",
@@ -1572,6 +1591,20 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,12 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "current_platform"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
-
-[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,7 +1046,6 @@ version = "0.0.0"
 dependencies = [
  "cfg-if",
  "color-eyre",
- "current_platform",
  "eyre",
  "geiger",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ libloading = "0.7.2"
 toml = "0.5"
 tempdir = "0.3.7" # for building crates
 current_platform = "0.2.0" # uses a build.rs
+tempfile = "3.3.0"
 
 # error handling, tracing, formatting
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ pgx-pg-config = { version = "0.6.0-alpha.1" }
 libloading = "0.7.2"
 toml = "0.5"
 tempdir = "0.3.7" # for building crates
-current_platform = "0.2.0" # uses a build.rs
 tempfile = "3.3.0"
 
 # error handling, tracing, formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "PostgreSQL Open Source License"
 description = "A Rust procedural language for PostgreSQL"
 homepage = "https://github.com/zombodb/plrust/"
 repository = "https://github.com/zombodb/plrust/"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -24,14 +24,22 @@ sum_array
 */
 ```
 
-# Options
+# Configuration
 
-There are two `postgresql.conf` settings that must be configured:
+First, plrust must be configured as a `shared_preload_libraries` entry in `postgresql.conf`.  For example:
+
+```
+shared_preload_libraries = 'plrust'
+```
+
+Failure to do so will cause unexpected behavior around the DROP FUNCTION, DROP SCHEMA, and ALTER FUNCTION commands.
+
+Additionally, there are two `postgresql.conf` settings that must be configured:
 
 Option | Description
 --------------|-----------
-`plrust.pg_config` | The full path of the `pg_config` binary.
-`plrust.work_dir` | The directory where pl/rust will build functions with cargo.
+`plrust.pg_config` | The full path of the `pg_config` binary (required).
+`plrust.work_dir` | The directory where pl/rust will build functions with cargo (required).
 `plrust.tracing_level` | A [tracing directive][docs-rs-tracing-directive]. (Default `info`)
 
 [github-pgx]: https://github.com/zombodb/pgx

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,6 @@ pub(crate) enum PlRustError {
     ParsingCodeBlock(syn::Error),
     #[error("Parsing error at span `{:?}`", .0.span())]
     Parse(#[from] syn::Error),
-    #[error("No plrust.plrust_proc entry for ({0}, {1}, {2}")]
-    NoProcEntry(pgx::pg_sys::Oid, &'static str, &'static str),
+    #[error("No plrust.plrust_proc entry for ({0}, {1})")]
+    NoProcEntry(pgx::pg_sys::Oid, String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,4 +34,6 @@ pub(crate) enum PlRustError {
     ParsingCodeBlock(syn::Error),
     #[error("Parsing error at span `{:?}`", .0.span())]
     Parse(#[from] syn::Error),
+    #[error("No plrust.plrust_proc entry for ({0}, {1}, {2}")]
+    NoProcEntry(pgx::pg_sys::Oid, &'static str, &'static str),
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,215 @@
+use std::ffi::CStr;
+
+use pgx::pg_sys::DropStmt;
+use pgx::{
+    pg_guard, pg_sys, FromDatum, IntoDatum, PgBox, PgBuiltInOids, PgList, PgLogLevel,
+    PgSqlErrorCode, Spi,
+};
+
+use crate::{plrust_lang_oid, plrust_proc};
+
+static mut PREVIOUS_PROCESS_UTILITY_HOOK: pg_sys::ProcessUtility_hook_type = None;
+
+pub(crate) fn init() {
+    unsafe {
+        // SAFETY:  Postgres will have set ProcessUtility_hook to a valid pointer (even if the
+        // null pointer) long before this function is called
+        PREVIOUS_PROCESS_UTILITY_HOOK = pg_sys::ProcessUtility_hook;
+        pg_sys::ProcessUtility_hook = Some(plrust_process_utility_hook);
+    }
+}
+
+#[pg_guard]
+unsafe extern "C" fn plrust_process_utility_hook(
+    pstmt: *mut pg_sys::PlannedStmt,
+    query_string: *const ::std::os::raw::c_char,
+    read_only_tree: bool,
+    context: pg_sys::ProcessUtilityContext,
+    params: pg_sys::ParamListInfo,
+    query_env: *mut pg_sys::QueryEnvironment,
+    dest: *mut pg_sys::DestReceiver,
+    qc: *mut pg_sys::QueryCompletion,
+) {
+    let pstmt = PgBox::from_pg(pstmt);
+    let utility_stmt = PgBox::from_pg(pstmt.utilityStmt);
+
+    // examine the UtilityStatement itself.  We're interested in three different commands,
+    // "DROP FUNCTION", "DROP SCHEMA", and "ALTER FUNCTION".  Two different node types are used
+    // for these -- `DropStmt` and `AlterFunctionStmt`
+
+    if utility_stmt.type_ == pg_sys::NodeTag_T_DropStmt {
+        let drop_stmt = PgBox::from_pg(pstmt.utilityStmt.cast::<pg_sys::DropStmt>());
+
+        // in the case of DropStmt, if the object being dropped is a FUNCTION or a SCHEMA, we'll
+        // go off and handle those two cases
+        match drop_stmt.removeType {
+            pg_sys::ObjectType_OBJECT_FUNCTION => handle_drop_function(&drop_stmt),
+            pg_sys::ObjectType_OBJECT_SCHEMA => handle_drop_schema(&drop_stmt),
+            _ => {
+                // we don't do anything for the other objects
+            }
+        }
+    } else if utility_stmt.type_ == pg_sys::NodeTag_T_AlterFunctionStmt {
+        let alter_stmt = PgBox::from_pg(pstmt.utilityStmt.cast::<pg_sys::AlterFunctionStmt>());
+
+        // and for AlterFunctioStmt, we'll just go do it.
+        handle_alter_function(&alter_stmt);
+    }
+
+    if PREVIOUS_PROCESS_UTILITY_HOOK.is_some() {
+        // previous hook must go last as we need the catalog entries this utility statement might
+        // operate on to be valid
+        let prev_hook = PREVIOUS_PROCESS_UTILITY_HOOK.as_ref().unwrap();
+        prev_hook(
+            pstmt.into_pg(),
+            query_string,
+            read_only_tree,
+            context,
+            params,
+            query_env,
+            dest,
+            qc,
+        );
+    } else {
+        // otherwise if there isn't one, we are the first to hook ProcessUtility, so ask Postgres
+        // to do whatever it wants to do with this statement
+        pg_sys::standard_ProcessUtility(
+            pstmt.into_pg(),
+            query_string,
+            read_only_tree,
+            context,
+            params,
+            query_env,
+            dest,
+            qc,
+        );
+    }
+}
+
+/// if the function being altered is `LANGUAGE plrust`, block any attempted change to the `STRICT`
+/// property, even if to the current value
+unsafe fn handle_alter_function(alter_stmt: &PgBox<pg_sys::AlterFunctionStmt>) {
+    let pg_proc_oid = pg_sys::LookupFuncWithArgs(alter_stmt.objtype, alter_stmt.func, false);
+    let lang_oid = lookup_func_lang(pg_proc_oid);
+
+    if lang_oid == plrust_lang_oid() {
+        // block a change to the 'STRICT' property
+        let actions = PgList::<pg_sys::DefElem>::from_pg(alter_stmt.actions);
+        for defelem in actions.iter_ptr() {
+            static STRICT: &str = "strict";
+
+            let defelem = PgBox::from_pg(defelem);
+            let name = CStr::from_ptr(defelem.defname);
+
+            if name.to_string_lossy().eq_ignore_ascii_case(STRICT) {
+                pgx::ereport!(PgLogLevel::ERROR,
+                    PgSqlErrorCode::ERRCODE_FEATURE_NOT_SUPPORTED,
+                    "plrust functions cannot have their STRICT property altered",
+                    "Use 'CREATE OR REPLACE FUNCTION' to alter the STRICT-ness of an existing plrust function"
+                );
+            }
+        }
+    }
+}
+
+/// drop all the `LANGUAGE plrust` functions from the set of all functions being dropped by the [`DropStmt`]
+unsafe fn handle_drop_function(drop_stmt: &PgBox<DropStmt>) {
+    let plrust_lang_oid = plrust_lang_oid();
+
+    for pg_proc_oid in objects(drop_stmt, pg_sys::ProcedureRelationId).filter_map(|oa| {
+        let lang_oid = lookup_func_lang(oa.objectId);
+        // if it's a pl/rust function we can drop it
+        (lang_oid == plrust_lang_oid).then(|| oa.objectId)
+    }) {
+        plrust_proc::drop_function(pg_proc_oid);
+    }
+}
+
+/// drop all `LANGUAGE plrust` functions in any of the schemas being dropped by the [`DropStmt`]
+unsafe fn handle_drop_schema(drop_stmt: &PgBox<DropStmt>) {
+    for object in objects(drop_stmt, pg_sys::NamespaceRelationId) {
+        for pg_proc_oid in all_in_namespace(object.objectId) {
+            plrust_proc::drop_function(pg_proc_oid)
+        }
+    }
+}
+
+/// Returns an iterator over the `objects` in the `[DropStmt]`, filtered by only those of the
+/// specified `filter_class_id`
+unsafe fn objects(
+    drop_stmt: &PgBox<DropStmt>,
+    filter_class_id: pg_sys::Oid,
+) -> impl Iterator<Item = pg_sys::ObjectAddress> {
+    PgList::<pg_sys::Node>::from_pg(drop_stmt.objects)
+        .iter_ptr()
+        .map(move |object| {
+            let mut rel = std::ptr::null_mut();
+            pg_sys::get_object_address(
+                drop_stmt.removeType,
+                object,
+                &mut rel,
+                pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
+                drop_stmt.missing_ok,
+            )
+        })
+        .filter(move |oa| oa.classId == filter_class_id && oa.objectId != pg_sys::InvalidOid)
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+/// Returns an Iterator of `LANGUAGE plrust` function oids (`pg_catalog.pg_proc.oid`) in a specific namespace
+#[tracing::instrument(level = "debug")]
+pub(crate) fn all_in_namespace(pg_namespace_oid: pg_sys::Oid) -> Vec<pg_sys::Oid> {
+    Spi::connect(|client| {
+        let results = client.select(
+            r#"
+                        SELECT oid
+                        FROM pg_catalog.pg_proc
+                        WHERE pronamespace = $1
+                          AND prolang = (SELECT oid FROM pg_catalog.pg_language WHERE lanname = 'plrust')
+                  "#,
+            None,
+            Some(vec![(
+                PgBuiltInOids::OIDOID.oid(),
+                pg_namespace_oid.into_datum(),
+            )]),
+        );
+
+        let proc_oids = results
+            .into_iter()
+            .map(|row| {
+                row.by_ordinal(1)
+                    .ok()
+                    .unwrap()
+                    .value::<pg_sys::Oid>()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Some(proc_oids))
+    }).unwrap()
+}
+
+/// Return the specified function's `prolang` value from `pg_catalog.pg_proc`
+unsafe fn lookup_func_lang(pg_proc_oid: pg_sys::Oid) -> Option<pg_sys::Oid> {
+    let cache_entry = pg_sys::SearchSysCache1(
+        pg_sys::SysCacheIdentifier_PROCOID as i32,
+        pg_proc_oid.into_datum().unwrap(),
+    );
+    if !cache_entry.is_null() {
+        let mut is_null = false;
+        let lang_datum = pg_sys::SysCacheGetAttr(
+            pg_sys::SysCacheIdentifier_PROCOID as i32,
+            cache_entry,
+            pg_sys::Anum_pg_proc_prolang as pg_sys::AttrNumber,
+            &mut is_null,
+        );
+        // SAFETY:  the datum will never be null -- postgres has a NOT NULL constraint on prolang
+        let lang_oid = pg_sys::Oid::from_datum(lang_datum, is_null).unwrap();
+        pg_sys::ReleaseSysCache(cache_entry);
+
+        Some(lang_oid)
+    } else {
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pgx::pg_module_magic!();
 /// this function will raise an ERROR if the `plrust` language isn't installed
 pub(crate) fn plrust_lang_oid() -> Option<pg_sys::Oid> {
     static PLRUST_LANG_NAME: &[u8] = b"plrust\0"; // want this to look like a c string
+    // SAFETY: We pass `missing_ok: false`, which will cause an error if not found.
+    // So we always will return a valid Oid if we return at all.
+    // The first parameter has the same requirements as `&CStr`.
     Some(unsafe { pg_sys::get_language_oid(PLRUST_LANG_NAME.as_ptr().cast(), false) })
 }
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -85,7 +85,7 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let shared_object = built.shared_object();
 
     // store the shared object in our table
-    plrust_proc::insert(fn_oid, shared_object)?;
+    plrust_proc::create_or_replace_function(fn_oid, shared_object)?;
 
     // cleanup after ourselves
     tracing::trace!("removing {}", shared_object.display());

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -69,7 +69,7 @@ pub(crate) unsafe fn evaluate_function(
     })
 }
 
-// #[tracing::instrument(level = "debug")]
+#[tracing::instrument(level = "debug")]
 pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let work_dir = gucs::work_dir();
     let pg_config = gucs::pg_config();

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -8,7 +8,7 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 */
 
 use crate::{
-    gucs,
+    gucs, plrust_proc,
     user_crate::{StateLoaded, UserCrate},
 };
 
@@ -16,8 +16,6 @@ use pgx::{pg_sys::FunctionCallInfo, pg_sys::MyDatabaseId, prelude::*};
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, HashMap},
-    env::consts::DLL_SUFFIX,
-    path::PathBuf,
     process::Output,
 };
 
@@ -51,34 +49,13 @@ pub(crate) unsafe fn evaluate_function(
 ) -> eyre::Result<pg_sys::Datum> {
     LOADED_SYMBOLS.with(|loaded_symbols| {
         let mut loaded_symbols_handle = loaded_symbols.borrow_mut();
-        // SAFETY: Postgres globally sets this to `const InvalidOid`, so is always read-safe,
-        // then writes it only during initialization, so we should not be racing anyone.
-        let db_oid = unsafe { MyDatabaseId };
         let user_crate_loaded = match loaded_symbols_handle.entry(fn_oid) {
             entry @ Entry::Occupied(_) => {
                 entry.or_insert_with(|| unreachable!("Occupied entry was vacant"))
             }
             entry @ Entry::Vacant(_) => {
-                let crate_name = crate_name(db_oid, fn_oid);
-                let mut shared_object_name = crate_name;
-                #[cfg(any(
-                    all(target_os = "macos", target_arch = "x86_64"),
-                    feature = "force_enable_x86_64_darwin_generations"
-                ))]
-                {
-                    let (latest, _path) =
-                        crate::generation::latest_generation(&shared_object_name, true)
-                            .unwrap_or_default();
-
-                    shared_object_name.push_str(&format!("_{}", latest));
-                };
-                shared_object_name.push_str(DLL_SUFFIX);
-
-                let shared_library = gucs::work_dir().join(&shared_object_name);
-                let user_crate_built = UserCrate::built(db_oid, fn_oid, shared_library);
-                let user_crate_loaded = unsafe { user_crate_built.load()? };
-
-                entry.or_insert(user_crate_loaded)
+                let loaded = plrust_proc::load(fn_oid)?;
+                entry.or_insert(loaded)
             }
         };
 
@@ -92,8 +69,8 @@ pub(crate) unsafe fn evaluate_function(
     })
 }
 
-#[tracing::instrument(level = "debug")]
-pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<(PathBuf, Output)> {
+// #[tracing::instrument(level = "debug")]
+pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let work_dir = gucs::work_dir();
     let pg_config = gucs::pg_config();
     let target_dir = work_dir.join("target");
@@ -103,11 +80,20 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<(PathBuf, Ou
 
     let generated = unsafe { UserCrate::try_from_fn_oid(db_oid, fn_oid)? };
     let provisioned = generated.provision(&work_dir)?;
-    let (built, output) = provisioned.build(&work_dir, pg_config, Some(target_dir.as_path()))?;
-
+    let crate_dir = provisioned.crate_dir().to_path_buf();
+    let (built, output) = provisioned.build(pg_config, target_dir.as_path())?;
     let shared_object = built.shared_object();
 
-    Ok((shared_object.into(), output))
+    // store the shared object in our table
+    plrust_proc::insert(fn_oid, shared_object)?;
+
+    // cleanup after ourselves
+    tracing::trace!("removing {}", shared_object.display());
+    std::fs::remove_file(shared_object)?;
+    tracing::trace!("removing {}", crate_dir.display());
+    std::fs::remove_dir_all(crate_dir)?;
+
+    Ok(output)
 }
 
 pub(crate) fn crate_name(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid) -> String {

--- a/src/plrust_proc.rs
+++ b/src/plrust_proc.rs
@@ -86,7 +86,7 @@ pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoad
 
     // fabricate a StateBuilt version of the UserCrate so that we can "load()" it -- tho we're
     // long since past the idea of crates, but whatev, I just work here
-    let built = UserCrate::built(db_oid, pg_proc_oid, temp_so_file.path());
+    let built = UserCrate::built(db_oid, pg_proc_oid, temp_so_file.path().to_path_buf());
     let loaded = unsafe { built.load()? };
 
     // just to be obvious, the temp_so_file gets deleted here.  Now that it's been loaded, we don't
@@ -98,6 +98,8 @@ pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoad
     Ok(loaded)
 }
 
+/// helper function to build a vec of Spi arguments to be used as the composite primary key
+/// `plrust.plrust_proc` needs to locate a function
 #[inline]
 fn pkey_datums(pg_proc_oid: pg_sys::Oid) -> Vec<(PgOid, Option<pg_sys::Datum>)> {
     vec![

--- a/src/plrust_proc.rs
+++ b/src/plrust_proc.rs
@@ -71,7 +71,7 @@ pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoad
         "SELECT so FROM plrust.plrust_proc WHERE (id, target_triple) = ($1, $2)",
         pkey_datums(pg_proc_oid),
     )
-    .ok_or(PlRustError::NoProcEntry(pg_proc_oid, get_target_triple()))?;
+    .ok_or_else(|| PlRustError::NoProcEntry(pg_proc_oid, get_target_triple().to_string()))?;
 
     // we write the shared object (`so`) bytes out to a temporary file rooted in our
     // configured `plrust.work_dir`.  This will get removed from disk when this function
@@ -114,6 +114,7 @@ fn pkey_datums(pg_proc_oid: pg_sys::Oid) -> Vec<(PgOid, Option<pg_sys::Datum>)> 
 /// Assumes the `target_triple` for the current host is that of the one which compiled the plrust
 /// extension shared library itself.
 #[inline]
-fn get_target_triple() -> String {
-    std::env!("TARGET").to_string()
+pub(crate) const fn get_target_triple() -> &'static str {
+    // NB: This gets set in our `build.rs`
+    env!("TARGET")
 }

--- a/src/plrust_proc.rs
+++ b/src/plrust_proc.rs
@@ -1,0 +1,99 @@
+//! Routines for managing the `plrust.plrust_proc` extension table along with the data it contains
+use crate::error::PlRustError;
+use crate::gucs;
+use crate::user_crate::{StateLoaded, UserCrate};
+use pgx::pg_sys::MyDatabaseId;
+use pgx::{extension_sql, pg_sys, IntoDatum, PgBuiltInOids, PgOid, Spi};
+use std::path::Path;
+
+extension_sql!(
+    r#"
+CREATE TYPE supported_arch AS ENUM (
+    'aarch64',
+    'x86_64'
+);
+CREATE TABLE plrust_proc (
+    id   regproc            NOT NULL,
+    arch supported_arch     NOT NULL,
+    os   text               NOT NULL,
+    so   bytea              NOT NULL,
+    PRIMARY KEY(id, arch, os)
+    --
+    -- Would be nice if we could make a foreign key over to pg_catalog.pg_proc
+    -- but that's okay.  We'll be managing access to this table ourselves
+    --
+    -- CONSTRAINT ft_pg_proc_oid FOREIGN KEY(id) REFERENCES pg_catalog.pg_proc(oid)
+);
+SELECT pg_catalog.pg_extension_config_dump('plrust_proc', '');
+
+"#,
+    name = "extschema"
+);
+
+/// Insert a new row into the `plrust.plrust_proc` table to represent the shared library at the
+/// specified `so_path`.  This function intuits the `arch` and `os` values from the current runtime
+#[tracing::instrument(level = "debug")]
+pub(crate) fn insert(pg_proc_oid: pg_sys::Oid, so_path: &Path) -> eyre::Result<()> {
+    let so = std::fs::read(so_path)?;
+    let mut args = pkey_datums(pg_proc_oid);
+    args.push((PgBuiltInOids::BYTEAOID.oid(), so.into_datum()));
+
+    Spi::run_with_args(
+            "INSERT INTO plrust.plrust_proc(id, arch, os, so) VALUES ($1, $2::plrust.supported_arch, $3, $4)",
+            Some(args),
+        );
+    Ok(())
+}
+
+/// Dynamically load the shared library stored in `plrust.plrust_proc` for the specified `pg_proc_oid`
+/// procedure object id.  The function intuits the `arch` and `os` values from the current runtime
+#[tracing::instrument(level = "debug")]
+pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoaded>> {
+    // using SPI, read the plrust_proc entry for the provided pg_proc.oid value
+    let so = Spi::get_one_with_args::<&[u8]>(
+        "SELECT so FROM plrust.plrust_proc WHERE (id, arch, os) = ($1, $2::plrust.supported_arch, $3)",
+        pkey_datums(pg_proc_oid),
+        )
+        .ok_or(PlRustError::NoProcEntry(
+            pg_proc_oid,
+            std::env::consts::ARCH,
+            std::env::consts::OS,
+        ))?;
+
+    // we write the shared object (`so`) bytes out to a temporary file rooted in our
+    // configured `plrust.work_dir`.  This will get removed from disk when this function
+    // exists, which is fine because we'll have dlopen()'d it by then and no longer need it
+    let work_dir = gucs::work_dir();
+    let temp_so_file = tempfile::Builder::new().tempfile_in(work_dir)?;
+    std::fs::write(&temp_so_file, so)?;
+
+    // SAFETY: Postgres globally sets this to `const InvalidOid`, so is always read-safe,
+    // then writes it only during initialization, so we should not be racing anyone.
+    let db_oid = unsafe { MyDatabaseId };
+
+    // fabricate a StateBuilt version of the UserCrate so that we can "load()" it -- tho we're
+    // long since past the idea of crates, but whatev, I just work here
+    let built = UserCrate::built(db_oid, pg_proc_oid, temp_so_file.path());
+    let loaded = unsafe { built.load()? };
+
+    // just to be clear, the temp_so_file gets deleted here -- it does not stick around after
+    // we've dlopen()'d it
+    drop(temp_so_file);
+
+    // all good
+    Ok(loaded)
+}
+
+fn pkey_datums(pg_proc_oid: pg_sys::Oid) -> Vec<(PgOid, Option<pg_sys::Datum>)> {
+    vec![
+        (PgBuiltInOids::REGPROCOID.oid(), pg_proc_oid.into_datum()),
+        (
+            PgBuiltInOids::TEXTOID.oid(),
+            std::env::consts::ARCH.into_datum(),
+        ),
+        (
+            PgBuiltInOids::TEXTOID.oid(),
+            std::env::consts::OS.into_datum(),
+        ),
+    ]
+}

--- a/src/plrust_proc.rs
+++ b/src/plrust_proc.rs
@@ -8,63 +8,70 @@ use std::path::Path;
 
 extension_sql!(
     r#"
-CREATE TYPE supported_arch AS ENUM (
-    'aarch64',
-    'x86_64'
-);
-CREATE TABLE plrust_proc (
-    id   regproc            NOT NULL,
-    arch supported_arch     NOT NULL,
-    os   text               NOT NULL,
-    so   bytea              NOT NULL,
-    PRIMARY KEY(id, arch, os)
+CREATE TABLE plrust.plrust_proc (
+    id            regproc   NOT NULL,
+    target_triple text      NOT NULL,
+    so            bytea     NOT NULL,
+    PRIMARY KEY(id, target_triple)
+
     --
     -- Would be nice if we could make a foreign key over to pg_catalog.pg_proc
     -- but that's okay.  We'll be managing access to this table ourselves
     --
     -- CONSTRAINT ft_pg_proc_oid FOREIGN KEY(id) REFERENCES pg_catalog.pg_proc(oid)
 );
-SELECT pg_catalog.pg_extension_config_dump('plrust_proc', '');
-
+SELECT pg_catalog.pg_extension_config_dump('plrust.plrust_proc', '');
 "#,
-    name = "extschema"
+    name = "plrust_proc"
 );
 
-/// Insert a new row into the `plrust.plrust_proc` table to represent the shared library at the
-/// specified `so_path`.  This function intuits the `arch` and `os` values from the current runtime
+/// Insert a new row into the `plrust.plrust_proc` table using the bytes of the shared library at
+/// the specified `so_path`.
 #[tracing::instrument(level = "debug")]
-pub(crate) fn insert(pg_proc_oid: pg_sys::Oid, so_path: &Path) -> eyre::Result<()> {
+pub(crate) fn create_or_replace_function(
+    pg_proc_oid: pg_sys::Oid,
+    so_path: &Path,
+) -> eyre::Result<()> {
     let so = std::fs::read(so_path)?;
     let mut args = pkey_datums(pg_proc_oid);
     args.push((PgBuiltInOids::BYTEAOID.oid(), so.into_datum()));
 
+    tracing::debug!("inserting function oid `{pg_proc_oid}`");
     Spi::run_with_args(
         r#"
-                INSERT INTO plrust.plrust_proc(id, arch, os, so) 
-                     VALUES ($1, $2::plrust.supported_arch, $3, $4)
-                     ON CONFLICT 
-                         ON CONSTRAINT plrust_proc_pkey 
-                            DO UPDATE SET so = $4 WHERE (id, arch, os) = ($1, $2::plrust.supported_arch, $3)
+                INSERT INTO plrust.plrust_proc(id, target_triple, so)
+                     VALUES ($1, $2, $3)
+                     ON CONFLICT (id, target_triple)
+                        DO UPDATE SET so = $3
                 "#,
         Some(args),
     );
     Ok(())
 }
 
+#[tracing::instrument(level = "debug")]
+pub(crate) fn drop_function(pg_proc_oid: pg_sys::Oid) {
+    tracing::debug!("deleting function oid `{pg_proc_oid}`");
+    Spi::run_with_args(
+        "DELETE FROM plrust.plrust_proc WHERE id = $1",
+        Some(vec![(
+            PgBuiltInOids::REGPROCOID.oid(),
+            pg_proc_oid.into_datum(),
+        )]),
+    )
+}
+
 /// Dynamically load the shared library stored in `plrust.plrust_proc` for the specified `pg_proc_oid`
-/// procedure object id.  The function intuits the `arch` and `os` values from the current runtime
+/// procedure object id and the `target_triple` of the host.
 #[tracing::instrument(level = "debug")]
 pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoaded>> {
+    tracing::debug!("loading function oid `{pg_proc_oid}`");
     // using SPI, read the plrust_proc entry for the provided pg_proc.oid value
     let so = Spi::get_one_with_args::<&[u8]>(
-        "SELECT so FROM plrust.plrust_proc WHERE (id, arch, os) = ($1, $2::plrust.supported_arch, $3)",
+        "SELECT so FROM plrust.plrust_proc WHERE (id, target_triple) = ($1, $2)",
         pkey_datums(pg_proc_oid),
-        )
-        .ok_or(PlRustError::NoProcEntry(
-            pg_proc_oid,
-            std::env::consts::ARCH,
-            std::env::consts::OS,
-        ))?;
+    )
+    .ok_or(PlRustError::NoProcEntry(pg_proc_oid, get_target_triple()))?;
 
     // we write the shared object (`so`) bytes out to a temporary file rooted in our
     // configured `plrust.work_dir`.  This will get removed from disk when this function
@@ -82,24 +89,29 @@ pub(crate) fn load(pg_proc_oid: pg_sys::Oid) -> eyre::Result<UserCrate<StateLoad
     let built = UserCrate::built(db_oid, pg_proc_oid, temp_so_file.path());
     let loaded = unsafe { built.load()? };
 
-    // just to be clear, the temp_so_file gets deleted here -- it does not stick around after
-    // we've dlopen()'d it
+    // just to be obvious, the temp_so_file gets deleted here.  Now that it's been loaded, we don't
+    // need it.  If any of the above failed and returned an Error, it'll still get deleted when
+    // the function returns.
     drop(temp_so_file);
 
     // all good
     Ok(loaded)
 }
 
+#[inline]
 fn pkey_datums(pg_proc_oid: pg_sys::Oid) -> Vec<(PgOid, Option<pg_sys::Datum>)> {
     vec![
         (PgBuiltInOids::REGPROCOID.oid(), pg_proc_oid.into_datum()),
         (
             PgBuiltInOids::TEXTOID.oid(),
-            std::env::consts::ARCH.into_datum(),
-        ),
-        (
-            PgBuiltInOids::TEXTOID.oid(),
-            std::env::consts::OS.into_datum(),
+            get_target_triple().into_datum(),
         ),
     ]
+}
+
+/// Assumes the `target_triple` for the current host is that of the one which compiled the plrust
+/// extension shared library itself.
+#[inline]
+fn get_target_triple() -> String {
+    std::env!("TARGET").to_string()
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -601,6 +601,77 @@ mod tests {
         let result = Spi::get_one::<i32>("SELECT not_unique(1, 2);\n");
         assert_eq!(Some(1), result);
     }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic]
+    fn plrust_cant_change_strict_off() {
+        let definition = r#"
+            CREATE FUNCTION cant_change_strict_off() 
+            RETURNS int 
+            LANGUAGE plrust 
+            AS $$ Some(1) $$;
+        "#;
+        Spi::run(definition);
+        Spi::run("ALTER FUNCTION cant_change_strict() CALLED ON NULL INPUT");
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic]
+    fn plrust_cant_change_strict_on() {
+        let definition = r#"
+            CREATE FUNCTION cant_change_strict_on() 
+            RETURNS int 
+            LANGUAGE plrust 
+            AS $$ Some(1) $$;
+        "#;
+        Spi::run(definition);
+        Spi::run("ALTER FUNCTION cant_change_strict() RETURNS NULL ON NULL INPUT");
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    fn plrust_drop_function() {
+        let definition = r#"
+            CREATE FUNCTION drop_function() 
+            RETURNS int 
+            LANGUAGE plrust 
+            AS $$ Some(1) $$;
+        "#;
+        Spi::run(definition);
+        let oid = Spi::get_one::<pg_sys::Oid>(
+            "SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'drop_function'",
+        )
+        .expect("failed to lookup function oid");
+        Spi::run("DROP FUNCTION drop_function");
+        let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
+            "SELECT id FROM plrust.plrust_proc WHERE id = {oid}"
+        ));
+        assert!(our_id.is_none())
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    fn plrust_drop_schema() {
+        let definition = r#"
+            CREATE SCHEMA to_drop;
+            CREATE FUNCTION to_drop.drop_function() 
+            RETURNS int 
+            LANGUAGE plrust 
+            AS $$ Some(1) $$;
+        "#;
+        Spi::run(definition);
+        let oid = Spi::get_one::<pg_sys::Oid>(
+            "SELECT oid FROM pg_catalog.pg_proc WHERE oid = 'to_drop.drop_function'::regproc::oid",
+        )
+        .expect("failed to lookup function oid");
+        Spi::run("DROP SCHEMA to_drop CASCADE");
+        let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
+            "SELECT id FROM plrust.plrust_proc WHERE id = {oid}"
+        ));
+        assert!(our_id.is_none())
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -627,6 +698,11 @@ pub mod pg_test {
     }
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        vec![&*WORK_DIR, &*PG_CONFIG, &*LOG_LEVEL]
+        vec![
+            &*WORK_DIR,
+            &*PG_CONFIG,
+            &*LOG_LEVEL,
+            "shared_preload_libraries='plrust'",
+        ]
     }
 }

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -315,9 +315,9 @@ mod tests {
                 "Generated `Cargo.toml` differs from test (after formatting)",
             );
 
-            let provisioned = generated.provision(parent_dir.path())?;
+            let provisioned = generated.provision(&target_dir)?;
 
-            let (built, _output) = provisioned.build(pg_config, target_dir.as_path())?;
+            let (built, _output) = provisioned.build(pg_config, &target_dir)?;
 
             let _shared_object = built.shared_object();
 

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -90,8 +90,8 @@ impl UserCrate<StateProvisioned> {
 
 impl UserCrate<StateBuilt> {
     #[tracing::instrument(level = "debug")]
-    pub(crate) fn built(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid, shared_object: &Path) -> Self {
-        UserCrate(StateBuilt::new(db_oid, fn_oid, shared_object.to_path_buf()))
+    pub(crate) fn built(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid, shared_object: PathBuf) -> Self {
+        UserCrate(StateBuilt::new(db_oid, fn_oid, shared_object))
     }
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.0.db_oid(), fn_oid = %self.0.fn_oid()))]
     pub fn shared_object(&self) -> &Path {

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -225,7 +225,6 @@ mod tests {
     use pgx::*;
 
     use crate::user_crate::*;
-    use eyre::WrapErr;
     use quote::quote;
     use syn::parse_quote;
     use toml::toml;

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -1,4 +1,5 @@
 use crate::{
+    plrust_lang_oid,
     user_crate::{parse_source_and_deps, CrateState, CrateVariant, StateProvisioned},
     PlRustError,
 };
@@ -61,9 +62,7 @@ impl StateGenerated {
             &mut is_null,
         );
         let lang_oid = pg_sys::Oid::from_datum(lang_datum, is_null);
-        let plrust =
-            std::ffi::CString::new("plrust").expect("Expected `\"plrust\"` to be a valid CString");
-        if lang_oid != Some(pg_sys::get_language_oid(plrust.as_ptr(), false)) {
+        if lang_oid != plrust_lang_oid() {
             return Err(PlRustError::NotPlRustFunction(fn_oid))?;
         }
 

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -60,10 +60,7 @@ impl StateProvisioned {
         command.arg(target_str);
         command.env("PGX_PG_CONFIG_PATH", pg_config);
         command.env("CARGO_TARGET_DIR", &target_dir);
-        command.env(
-            "RUSTFLAGS",
-            "-Ctarget-cpu=native -Clink-args=-Wl,-undefined,dynamic_lookup",
-        );
+        command.env("RUSTFLAGS", "-Clink-args=-Wl,-undefined,dynamic_lookup");
 
         let output = command.output().wrap_err("`cargo` execution failure")?;
 


### PR DESCRIPTION
Move the ultimate storage of a plrust compiled function from disk to an extension table named `plrust.plrust_proc`.

The compilation process now cleans up after itself (we no longer leave any function-specific artifacts on disk, other than the shared `${PLRUST.WORK_DIR}target/` directory), and the .so bytes are inserted into the new `plrust.plrust_proc` table, tagged with the host's "target_triple", as the compiled pl/rust extension understands it.

Also enables plrust to properly work with `DROP FUNCTION`, `DROP SCHEMA`, and `ALTER FUNCTION` when a `LANGUAGE plrust` function is involved in one of those statements.  For the first two, we remove the corresponding entires in our `plrust.plrust_proc` table, for the latter we let everything pass except changes to the `STRICT` property.

The interception of those utility statements is done via a hook, which now means plrust needs to be configured as (at least) a `shared_preload_libraries` entry in `postgresql.conf`.

`CREATE OR REPLACE FUNCTION` is simply handled through the normal language handler API.

When we load a "function.so" for the first execution, it is bytes are streamed from `plrust.plrust_proc.so` to a temporary file in the configured `plrust.work_dir` directory, dlopen()'d and then immediately deleted from disk.

Loading a function necessitates that we have one already compiled for the current host "triple target".  If one doesn't exist currently plrust will raise an ERROR.  A future PR will address an automatic re-compilation scheme.

Also of note, plrust previously would compile the user function with `-Ctarget-cpu=native`.  This is no longer the case as it needs binaries to be compatible across same-target-triple-but-different-and-incompatible-cpu-capabilities.  Perhaps in the future this can be addressed in a more explicit manner.