### PR TITLE
 Crate-wide `#![deny(unsafe_op_in_unsafe_fn)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@ unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum
     }
 }
 
+/// Called by Postgres, not you.
+/// # Safety
+/// Don't.
 #[pg_extern]
 #[tracing::instrument(level = "debug")]
 // Don't call this!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 */
 
 #![doc = include_str!("../README.md")]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[deny(unsafe_op_in_unsafe_fn)]
 mod error;
@@ -84,6 +85,8 @@ unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum
     unsafe fn plrust_call_handler_inner(
         fcinfo: pg_sys::FunctionCallInfo,
     ) -> eyre::Result<pg_sys::Datum> {
+        // SAFETY: these seemingly innocent invocations of `as_ref` are actually `pointer::as_ref`
+        // but we should have been given this fcinfo by Postgres, so it should be fine
         let fn_oid = unsafe {
             fcinfo
                 .as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,25 +10,20 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-#[deny(unsafe_op_in_unsafe_fn)]
 mod error;
 #[cfg(any(
     all(target_os = "macos", target_arch = "x86_64"),
     feature = "force_enable_x86_64_darwin_generations"
 ))]
 mod generation;
-#[deny(unsafe_op_in_unsafe_fn)]
 mod gucs;
-#[deny(unsafe_op_in_unsafe_fn)]
 mod logging;
-#[deny(unsafe_op_in_unsafe_fn)]
 mod plrust;
 
 #[allow(unsafe_op_in_unsafe_fn)] // this code manipulates symbols, so should be carefully audited
 mod user_crate;
 
 #[cfg(any(test, feature = "pg_test"))]
-#[allow(unsafe_op_in_unsafe_fn)] // waiting on a PGX fix
 pub mod tests;
 
 use error::PlRustError;
@@ -80,7 +75,6 @@ CREATE FUNCTION plrust_call_handler() RETURNS language_handler
     LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
 ")]
 #[tracing::instrument(level = "debug")]
-#[deny(unsafe_op_in_unsafe_fn)]
 unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
     unsafe fn plrust_call_handler_inner(
         fcinfo: pg_sys::FunctionCallInfo,
@@ -113,8 +107,6 @@ unsafe fn plrust_call_handler(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum
 /// Don't.
 #[pg_extern]
 #[tracing::instrument(level = "debug")]
-// Don't call this!
-#[deny(unsafe_op_in_unsafe_fn)]
 unsafe fn plrust_validator(fn_oid: pg_sys::Oid, fcinfo: pg_sys::FunctionCallInfo) {
     unsafe fn plrust_validator_inner(
         fn_oid: pg_sys::Oid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ mod gucs;
 mod logging;
 mod plrust;
 
-#[allow(unsafe_op_in_unsafe_fn)] // this code manipulates symbols, so should be carefully audited
 mod user_crate;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -44,7 +44,6 @@ pub(crate) unsafe fn unload_function(fn_oid: pg_sys::Oid) {
 }
 
 #[tracing::instrument(level = "debug")]
-#[deny(unsafe_op_in_unsafe_fn)]
 pub(crate) unsafe fn evaluate_function(
     fn_oid: pg_sys::Oid,
     fcinfo: FunctionCallInfo,

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -46,7 +46,7 @@ impl UserCrate<StateGenerated> {
     }
     #[tracing::instrument(level = "debug", skip_all)]
     pub unsafe fn try_from_fn_oid(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid) -> eyre::Result<Self> {
-        StateGenerated::try_from_fn_oid(db_oid, fn_oid).map(Self)
+        unsafe { StateGenerated::try_from_fn_oid(db_oid, fn_oid).map(Self) }
     }
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn lib_rs(&self) -> eyre::Result<syn::File> {
@@ -96,14 +96,14 @@ impl UserCrate<StateBuilt> {
     }
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.0.db_oid(), fn_oid = %self.0.fn_oid()))]
     pub unsafe fn load(self) -> eyre::Result<UserCrate<StateLoaded>> {
-        self.0.load().map(UserCrate)
+        unsafe { self.0.load().map(UserCrate) }
     }
 }
 
 impl UserCrate<StateLoaded> {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid(), fn_oid = %self.fn_oid()))]
     pub unsafe fn evaluate(&self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-        self.0.evaluate(fcinfo)
+        unsafe { self.0.evaluate(fcinfo) }
     }
 
     pub(crate) fn close(self) -> eyre::Result<()> {

--- a/src/user_crate/state_built.rs
+++ b/src/user_crate/state_built.rs
@@ -35,6 +35,6 @@ impl StateBuilt {
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid, shared_object = %self.shared_object.display()))]
     pub(crate) unsafe fn load(self) -> eyre::Result<StateLoaded> {
-        StateLoaded::load(self.db_oid, self.fn_oid, self.shared_object)
+        unsafe { StateLoaded::load(self.db_oid, self.fn_oid, self.shared_object) }
     }
 }

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -37,6 +37,7 @@ impl StateGenerated {
     }
 
     #[tracing::instrument(level = "debug")]
+    #[allow(unsafe_op_in_unsafe_fn)] // TODO: A bit of a mess in here, fix this?
     pub(crate) unsafe fn try_from_fn_oid(
         db_oid: pg_sys::Oid,
         fn_oid: pg_sys::Oid,

--- a/src/user_crate/state_loaded.rs
+++ b/src/user_crate/state_loaded.rs
@@ -27,7 +27,7 @@ impl StateLoaded {
             "Loading {shared_object}",
             shared_object = shared_object.display()
         );
-        let library = Library::new(&shared_object)?;
+        let library = unsafe { Library::new(&shared_object)? };
         let crate_name = crate::plrust::crate_name(db_oid, fn_oid);
 
         #[cfg(any(
@@ -45,7 +45,7 @@ impl StateLoaded {
         let symbol_name = crate_name + "_wrapper";
 
         tracing::trace!("Getting symbol `{symbol_name}`");
-        let symbol = library.get(symbol_name.as_bytes())?;
+        let symbol = unsafe { library.get(symbol_name.as_bytes())? };
 
         Ok(Self {
             db_oid,
@@ -59,7 +59,7 @@ impl StateLoaded {
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid, ?fcinfo))]
     pub(crate) unsafe fn evaluate(&self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-        (self.symbol)(fcinfo)
+        unsafe { (self.symbol)(fcinfo) }
     }
 
     #[tracing::instrument(


### PR DESCRIPTION
The purpose of applying this lint on a crate-wide basis is to allow us to more easily find, audit, and verify `unsafe` code throughout the crate. A handler function that does most of the work during coalescing the actual function, unfortunately, is currently exempted, because it will otherwise have severe merge conflicts with https://github.com/tcdi/plrust/pull/122.

I have deliberately avoided adding `// SAFETY` annotations in the `user_crate` cases because I will find my current notes unsatisfactory (read: almost nonexistent) and I intend to come back later with the clippy lint that will force me to find them all and properly document them anyways.