### PR TITLE
Reload function.so when the function changes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,8 @@ pub(crate) enum PlRustError {
     CargoBuildFail,
     #[error("Generating `Cargo.toml`")]
     GeneratingCargoToml,
-    #[error("Function `{0}` was not a PL/Rust function")]
-    NotPlRustFunction(pgx::pg_sys::Oid),
+    #[error("Function `{0}` does not exist")]
+    NoSuchFunction(pgx::pg_sys::Oid),
     #[error("Oid `{0}` was not mappable to a Rust type")]
     NoOidToRustMapping(pgx::pg_sys::Oid),
     #[error("Generated Rust type (`{1}`) for `{0}` was unparsable: {2}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,8 +8,6 @@ pub(crate) enum PlRustError {
     NullFmgrInfo,
     #[error("The Procedure Tuple was NULL")]
     NullProcTuple,
-    #[error("The source code of the function was NULL")]
-    NullSourceCode,
     #[error("libloading error: {0}")]
     LibLoading(#[from] libloading::Error),
     #[cfg(any(

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -6,6 +6,7 @@ use pgx::{
     PgSqlErrorCode, Spi,
 };
 
+use crate::pgproc::PgProc;
 use crate::{plrust_lang_oid, plrust_proc};
 
 static mut PREVIOUS_PROCESS_UTILITY_HOOK: pg_sys::ProcessUtility_hook_type = None;
@@ -329,27 +330,6 @@ pub(crate) fn all_in_namespace(pg_namespace_oid: pg_sys::Oid) -> Vec<pg_sys::Oid
 
 /// Return the specified function's `prolang` value from `pg_catalog.pg_proc`
 fn lookup_func_lang(pg_proc_oid: pg_sys::Oid) -> Option<pg_sys::Oid> {
-    // SAFETY:  This whole function gets replaced in a follow-up PR.  You'll like it @workingjubilee, I promise!
-    unsafe {
-        let cache_entry = pg_sys::SearchSysCache1(
-            pg_sys::SysCacheIdentifier_PROCOID as i32,
-            pg_proc_oid.into_datum().unwrap(),
-        );
-        if !cache_entry.is_null() {
-            let mut is_null = false;
-            let lang_datum = pg_sys::SysCacheGetAttr(
-                pg_sys::SysCacheIdentifier_PROCOID as i32,
-                cache_entry,
-                pg_sys::Anum_pg_proc_prolang as pg_sys::AttrNumber,
-                &mut is_null,
-            );
-            // SAFETY:  the datum will never be null -- postgres has a NOT NULL constraint on prolang
-            let lang_oid = pg_sys::Oid::from_datum(lang_datum, is_null).unwrap();
-            pg_sys::ReleaseSysCache(cache_entry);
-
-            Some(lang_oid)
-        } else {
-            None
-        }
-    }
+    let meta = PgProc::new(pg_proc_oid)?;
+    Some(meta.prolang())
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -2,8 +2,7 @@
 use std::ffi::CStr;
 
 use pgx::{
-    pg_guard, pg_sys, FromDatum, IntoDatum, PgBox, PgBuiltInOids, PgList, PgLogLevel,
-    PgSqlErrorCode, Spi,
+    pg_guard, pg_sys, IntoDatum, PgBox, PgBuiltInOids, PgList, PgLogLevel, PgSqlErrorCode, Spi,
 };
 
 use crate::pgproc::PgProc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ mod plrust;
 mod user_crate;
 
 mod hooks;
-mod pgproc;
 mod plrust_proc;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod plrust;
 mod user_crate;
 
 mod hooks;
+mod pgproc;
 mod plrust_proc;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/pgproc.rs
+++ b/src/pgproc.rs
@@ -1,0 +1,96 @@
+use pgx::{pg_sys, FromDatum, IntoDatum};
+use std::mem::ManuallyDrop;
+use std::ptr::NonNull;
+
+/// Provides a safe wrapper around a Postgres "SysCache" entry from `pg_catalog.pg_proc`.
+pub(crate) struct PgProc {
+    inner: ManuallyDrop<NonNull<pg_sys::HeapTupleData>>,
+}
+
+impl Drop for PgProc {
+    fn drop(&mut self) {
+        unsafe { pg_sys::ReleaseSysCache(self.inner.assume_init().as_ptr()) }
+    }
+}
+
+impl PgProc {
+    pub(crate) fn new(pg_proc_oid: pg_sys::Oid) -> Option<PgProc> {
+        unsafe {
+            // SAFETY:  SearchSysCache1 will give us a valid HeapTuple or it'll return null.
+            // Either way, using NonNull::new()? will make the right decision for us
+            let entry = pg_sys::SearchSysCache1(
+                pg_sys::SysCacheIdentifier_PROCOID as _,
+                pg_proc_oid.into_datum().unwrap(),
+            );
+            Some(PgProc {
+                inner: ManuallyDrop::new(NonNull::new(entry)?),
+            })
+        }
+    }
+
+    pub(crate) fn xmin(&self) -> pg_sys::TransactionId {
+        // SAFETY:  self.inner will be valid b/c that's part of what pg_sys::SearchSysCache1()
+        // does for us.  Same is true for t_data
+        unsafe {
+            self.inner
+                .as_ref()
+                .t_data
+                .as_ref()
+                .unwrap()
+                .t_choice
+                .t_heap
+                .t_xmin
+        }
+    }
+
+    pub(crate) fn prolang(&self) -> pg_sys::Oid {
+        // SAFETY:  `prolang` has a NOT NULL constraint
+        self.get_attr(pg_sys::Anum_pg_proc_prolang).unwrap()
+    }
+
+    pub(crate) fn prosrc(&self) -> String {
+        // SAFETY:  `prosrc` has a NOT NULL constraint
+        self.get_attr(pg_sys::Anum_pg_proc_prosrc).unwrap()
+    }
+
+    pub(crate) fn proargnames(&self) -> Vec<Option<String>> {
+        self.get_attr(pg_sys::Anum_pg_proc_proargnames)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn proargtypes(&self) -> Vec<pg_sys::Oid> {
+        self.get_attr(pg_sys::Anum_pg_proc_proargtypes)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn prorettype(&self) -> pg_sys::Oid {
+        // SAFETY:  `prorettype` has a NOT NULL constraint
+        self.get_attr(pg_sys::Anum_pg_proc_prorettype).unwrap()
+    }
+
+    pub(crate) fn proisstrict(&self) -> bool {
+        // SAFETY: 'proisstrict' has a NOT NULL constraint
+        self.get_attr(pg_sys::Anum_pg_proc_proisstrict).unwrap()
+    }
+
+    pub(crate) fn proretset(&self) -> bool {
+        // SAFETY: 'proretset' has a NOT NULL constraint
+        self.get_attr(pg_sys::Anum_pg_proc_proretset).unwrap()
+    }
+
+    #[inline]
+    fn get_attr<T: FromDatum>(&self, attribute: u32) -> Option<T> {
+        unsafe {
+            // SAFETY:  SysCacheGetAttr will give us what we need to create a Datum of type T,
+            // and this PgProc type ensures we have a valid "arg_tup" pointer for the cache entry
+            let mut is_null = false;
+            let datum = pg_sys::SysCacheGetAttr(
+                pg_sys::SysCacheIdentifier_PROCOID as _,
+                self.inner.as_ptr(),
+                attribute as _,
+                &mut is_null,
+            );
+            T::from_datum(datum, is_null)
+        }
+    }
+}

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -129,6 +129,11 @@ impl UserCrate<StateLoaded> {
         self.0.symbol_name()
     }
 
+    #[inline]
+    pub(crate) fn xmin(&self) -> pg_sys::TransactionId {
+        self.0.xmin()
+    }
+
     pub(crate) fn fn_oid(&self) -> pg_sys::Oid {
         self.0.fn_oid()
     }

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -30,6 +30,7 @@ impl UserCrate<StateGenerated> {
     #[cfg(any(test, feature = "pg_test"))]
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn generated_for_tests(
+        pg_proc_xmin: pg_sys::TransactionId,
         db_oid: pg_sys::Oid,
         fn_oid: pg_sys::Oid,
         user_deps: toml::value::Table,
@@ -37,6 +38,7 @@ impl UserCrate<StateGenerated> {
         variant: CrateVariant,
     ) -> Self {
         Self(StateGenerated::for_tests(
+            pg_proc_xmin,
             db_oid,
             fn_oid,
             user_deps.into(),
@@ -90,8 +92,18 @@ impl UserCrate<StateProvisioned> {
 
 impl UserCrate<StateBuilt> {
     #[tracing::instrument(level = "debug")]
-    pub(crate) fn built(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid, shared_object: PathBuf) -> Self {
-        UserCrate(StateBuilt::new(db_oid, fn_oid, shared_object))
+    pub(crate) fn built(
+        pg_proc_xmin: pg_sys::TransactionId,
+        db_oid: pg_sys::Oid,
+        fn_oid: pg_sys::Oid,
+        shared_object: PathBuf,
+    ) -> Self {
+        UserCrate(StateBuilt::new(
+            pg_proc_xmin,
+            db_oid,
+            fn_oid,
+            shared_object.to_path_buf(),
+        ))
     }
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.0.db_oid(), fn_oid = %self.0.fn_oid()))]
     pub fn shared_object(&self) -> &Path {
@@ -117,11 +129,11 @@ impl UserCrate<StateLoaded> {
         self.0.symbol_name()
     }
 
-    pub(crate) fn fn_oid(&self) -> &u32 {
+    pub(crate) fn fn_oid(&self) -> pg_sys::Oid {
         self.0.fn_oid()
     }
 
-    pub(crate) fn db_oid(&self) -> &u32 {
+    pub(crate) fn db_oid(&self) -> pg_sys::Oid {
         self.0.db_oid()
     }
 
@@ -232,6 +244,7 @@ mod tests {
     #[pg_test]
     fn full_workflow() {
         fn wrapped() -> eyre::Result<()> {
+            let pg_proc_oid = 0 as pg_sys::TransactionId;
             let fn_oid = 0 as pg_sys::Oid;
             let db_oid = 1 as pg_sys::Oid;
             let target_dir = crate::gucs::work_dir();
@@ -250,8 +263,14 @@ mod tests {
                 { Some(arg0.to_string()) }
             })?;
 
-            let generated =
-                UserCrate::generated_for_tests(db_oid, fn_oid, user_deps, user_code, variant);
+            let generated = UserCrate::generated_for_tests(
+                pg_proc_oid,
+                db_oid,
+                fn_oid,
+                user_deps,
+                user_code,
+                variant,
+            );
             let crate_name = crate::plrust::crate_name(db_oid, fn_oid);
             #[cfg(any(
                 all(target_os = "macos", target_arch = "x86_64"),

--- a/src/user_crate/state_built.rs
+++ b/src/user_crate/state_built.rs
@@ -42,11 +42,15 @@ impl StateBuilt {
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid, shared_object = %self.shared_object.display()))]
     pub(crate) unsafe fn load(self) -> eyre::Result<StateLoaded> {
-        StateLoaded::load(
-            self.pg_proc_xmin,
-            self.db_oid,
-            self.fn_oid,
-            self.shared_object,
-        )
+        unsafe {
+            // SAFETY:  Caller is responsible for ensuring self.shared_object points to the proper
+            // shared library to be loaded
+            StateLoaded::load(
+                self.pg_proc_xmin,
+                self.db_oid,
+                self.fn_oid,
+                self.shared_object,
+            )
+        }
     }
 }

--- a/src/user_crate/state_built.rs
+++ b/src/user_crate/state_built.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 #[must_use]
 pub(crate) struct StateBuilt {
+    pg_proc_xmin: pg_sys::TransactionId,
     db_oid: pg_sys::Oid,
     fn_oid: pg_sys::Oid,
     shared_object: PathBuf,
@@ -13,8 +14,14 @@ impl CrateState for StateBuilt {}
 
 impl StateBuilt {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn new(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid, shared_object: PathBuf) -> Self {
+    pub(crate) fn new(
+        pg_proc_xmin: pg_sys::TransactionId,
+        db_oid: pg_sys::Oid,
+        fn_oid: pg_sys::Oid,
+        shared_object: PathBuf,
+    ) -> Self {
         Self {
+            pg_proc_xmin,
             db_oid,
             fn_oid,
             shared_object,
@@ -25,16 +32,21 @@ impl StateBuilt {
         &self.shared_object
     }
 
-    pub(crate) fn fn_oid(&self) -> &u32 {
-        &self.fn_oid
+    pub(crate) fn fn_oid(&self) -> pg_sys::Oid {
+        self.fn_oid
     }
 
-    pub(crate) fn db_oid(&self) -> &u32 {
-        &self.db_oid
+    pub(crate) fn db_oid(&self) -> pg_sys::Oid {
+        self.db_oid
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid, shared_object = %self.shared_object.display()))]
     pub(crate) unsafe fn load(self) -> eyre::Result<StateLoaded> {
-        unsafe { StateLoaded::load(self.db_oid, self.fn_oid, self.shared_object) }
+        StateLoaded::load(
+            self.pg_proc_xmin,
+            self.db_oid,
+            self.fn_oid,
+            self.shared_object,
+        )
     }
 }

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -4,7 +4,7 @@ use crate::{
     PlRustError,
 };
 use eyre::WrapErr;
-use pgx::{pg_sys, FromDatum, IntoDatum, PgOid};
+use pgx::{pg_sys, PgOid};
 use quote::quote;
 use std::path::Path;
 

--- a/src/user_crate/state_loaded.rs
+++ b/src/user_crate/state_loaded.rs
@@ -92,7 +92,8 @@ impl StateLoaded {
         &self.symbol_name
     }
 
-    pub(crate) fn pg_prox_xmin(&self) -> pg_sys::TransactionId {
+    #[inline]
+    pub(crate) fn xmin(&self) -> pg_sys::TransactionId {
         self.pg_proc_xmin
     }
 


### PR DESCRIPTION
This PR, which is based on the changes in #122, reloads a function if it was changed by a concurrent transaction.  

It also cleans up our various syscache usages and centralizes them into a new type named `PgProc` in the `pgproc.rs` module.

Note, it'll be easier to review this after #122 is merged.