### PR TITLE
Now `#![forbid(unsafe_op_in_unsafe_fn)]`

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,4 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
 use std::ffi::CStr;
 
 use pgx::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 */
 
 #![doc = include_str!("../README.md")]
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod error;
 #[cfg(any(

--- a/src/pgproc.rs
+++ b/src/pgproc.rs
@@ -8,6 +8,9 @@ pub(crate) struct PgProc {
 
 impl Drop for PgProc {
     fn drop(&mut self) {
+        // SAFETY: We have a valid pointer and this just decrements the reference count.
+        // This will generally get resolved by the end of the transaction anyways,
+        // but Postgres strongly recommends you do not do that.
         unsafe { pg_sys::ReleaseSysCache(self.inner.as_ptr()) }
     }
 }

--- a/src/pgproc.rs
+++ b/src/pgproc.rs
@@ -1,10 +1,9 @@
 use pgx::{pg_sys, FromDatum, IntoDatum};
-use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 
 /// Provides a safe wrapper around a Postgres "SysCache" entry from `pg_catalog.pg_proc`.
 pub(crate) struct PgProc {
-    inner: ManuallyDrop<NonNull<pg_sys::HeapTupleData>>,
+    inner: NonNull<pg_sys::HeapTupleData>,
 }
 
 impl Drop for PgProc {
@@ -24,7 +23,7 @@ impl PgProc {
                 pg_proc_oid.into_datum().unwrap(),
             );
             Some(PgProc {
-                inner: ManuallyDrop::new(NonNull::new(entry)?),
+                inner: NonNull::new(entry)?,
             })
         }
     }

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -41,7 +41,6 @@ impl StateGenerated {
     }
 
     #[tracing::instrument(level = "debug")]
-    #[allow(unsafe_op_in_unsafe_fn)] // TODO: A bit of a mess in here, fix this?
     pub(crate) unsafe fn try_from_fn_oid(
         db_oid: pg_sys::Oid,
         fn_oid: pg_sys::Oid,


### PR DESCRIPTION
This finally gets us to no-exceptions `#![deny(unsafe_op_in_unsafe_fn)]`, thanks to #124!