### PR TITLE
Catch `#[no_mangle]`

### DIFF
--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -107,7 +107,8 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let provisioned = generated.provision(&work_dir)?;
     // We want to introduce validation here.
     let crate_dir = provisioned.crate_dir().to_path_buf();
-    let (built, output) = provisioned.build(pg_config, target_dir.as_path())?;
+    let (validated, output) = provisioned.validate(pg_config, target_dir.as_path())?;;
+    let (built, output) = validated.build(pg_config, target_dir.as_path())?;
     let shared_object = built.shared_object();
 
     // store the shared object in our table

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -108,7 +108,7 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     // We want to introduce validation here.
     let crate_dir = provisioned.crate_dir().to_path_buf();
     let (validated, output) = provisioned.validate(pg_config, target_dir.as_path())?;;
-    let (built, output) = validated.build(pg_config, target_dir.as_path())?;
+    let (built, output) = validated.build(target_dir.as_path())?;
     let shared_object = built.shared_object();
 
     // store the shared object in our table

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -107,7 +107,7 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let provisioned = generated.provision(&work_dir)?;
     // We want to introduce validation here.
     let crate_dir = provisioned.crate_dir().to_path_buf();
-    let (validated, output) = provisioned.validate(pg_config, target_dir.as_path())?;;
+    let (validated, _output) = provisioned.validate(pg_config, target_dir.as_path())?;
     let (built, output) = validated.build(target_dir.as_path())?;
     let shared_object = built.shared_object();
 

--- a/src/plrust.rs
+++ b/src/plrust.rs
@@ -105,6 +105,7 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
 
     let generated = unsafe { UserCrate::try_from_fn_oid(db_oid, fn_oid)? };
     let provisioned = generated.provision(&work_dir)?;
+    // We want to introduce validation here.
     let crate_dir = provisioned.crate_dir().to_path_buf();
     let (built, output) = provisioned.build(pg_config, target_dir.as_path())?;
     let shared_object = built.shared_object();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -755,6 +755,9 @@ mod tests {
         assert!(our_id.is_none())
     }
 
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic(expected = "error: declaration of a `no_mangle` static")]
     fn plrust_no_link_section() {
         let definition = r#"
             CREATE OR REPLACE FUNCTION vapt() RETURNS BIGINT

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -754,6 +754,36 @@ mod tests {
         ));
         assert!(our_id.is_none())
     }
+
+    fn plrust_no_link_section() {
+        let definition = r#"
+            CREATE OR REPLACE FUNCTION vapt() RETURNS BIGINT
+            IMMUTABLE STRICT
+            LANGUAGE PLRUST AS
+            $$
+                #[no_mangle]
+                #[link_section = ".init_array"]
+                pub static INITIALIZE: &[u8; 136] = &GOGO;
+
+                #[no_mangle]
+                #[link_section = ".text"]
+                pub static GOGO: [u8; 136] = [
+                    72, 184, 1, 1, 1, 1, 1, 1, 1, 1, 80, 72, 184, 46, 99, 104, 111, 46, 114, 105, 1, 72, 49, 4,
+                    36, 72, 137, 231, 106, 1, 254, 12, 36, 72, 184, 99, 102, 105, 108, 101, 49, 50, 51, 80, 72,
+                    184, 114, 47, 116, 109, 112, 47, 112, 111, 80, 72, 184, 111, 117, 99, 104, 32, 47, 118, 97,
+                    80, 72, 184, 115, 114, 47, 98, 105, 110, 47, 116, 80, 72, 184, 1, 1, 1, 1, 1, 1, 1, 1, 80,
+                    72, 184, 114, 105, 1, 44, 98, 1, 46, 116, 72, 49, 4, 36, 49, 246, 86, 106, 14, 94, 72, 1,
+                    230, 86, 106, 19, 94, 72, 1, 230, 86, 106, 24, 94, 72, 1, 230, 86, 72, 137, 230, 49, 210,
+                    106, 59, 88, 15, 5,
+                ];
+
+                Some(1)
+            $$;
+        "#;
+        Spi::run(definition);
+        let result = Spi::get_one::<i32>("SELECT vapt();\n");
+        assert_eq!(Some(1), result);
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -758,9 +758,9 @@ mod tests {
     #[pg_test]
     #[search_path(@extschema@)]
     #[should_panic(expected = "error: declaration of a `no_mangle` static")]
-    fn plrust_no_link_section() {
+    fn plrust_block_unsafe_no_mangle() {
         let definition = r#"
-            CREATE OR REPLACE FUNCTION vapt() RETURNS BIGINT
+            CREATE OR REPLACE FUNCTION no_mangle() RETURNS BIGINT
             IMMUTABLE STRICT
             LANGUAGE PLRUST AS
             $$
@@ -784,7 +784,39 @@ mod tests {
             $$;
         "#;
         Spi::run(definition);
-        let result = Spi::get_one::<i32>("SELECT vapt();\n");
+        let result = Spi::get_one::<i32>("SELECT no_mangle();\n");
+        assert_eq!(Some(1), result);
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic(expected = "error: declaration of a static with `link_section`")]
+    #[ignore] // TODO: raise MSRV
+    fn plrust_block_unsafe_link_section() {
+        let definition = r#"
+            CREATE OR REPLACE FUNCTION link_section() RETURNS BIGINT
+            IMMUTABLE STRICT
+            LANGUAGE PLRUST AS
+            $$
+                #[link_section = ".init_array"]
+                pub static INITIALIZE: &[u8; 136] = &GOGO;
+
+                #[link_section = ".text"]
+                pub static GOGO: [u8; 136] = [
+                    72, 184, 1, 1, 1, 1, 1, 1, 1, 1, 80, 72, 184, 46, 99, 104, 111, 46, 114, 105, 1, 72, 49, 4,
+                    36, 72, 137, 231, 106, 1, 254, 12, 36, 72, 184, 99, 102, 105, 108, 101, 49, 50, 51, 80, 72,
+                    184, 114, 47, 116, 109, 112, 47, 112, 111, 80, 72, 184, 111, 117, 99, 104, 32, 47, 118, 97,
+                    80, 72, 184, 115, 114, 47, 98, 105, 110, 47, 116, 80, 72, 184, 1, 1, 1, 1, 1, 1, 1, 1, 80,
+                    72, 184, 114, 105, 1, 44, 98, 1, 46, 116, 72, 49, 4, 36, 49, 246, 86, 106, 14, 94, 72, 1,
+                    230, 86, 106, 19, 94, 72, 1, 230, 86, 106, 24, 94, 72, 1, 230, 86, 72, 137, 230, 49, 210,
+                    106, 59, 88, 15, 5,
+                ];
+
+                Some(1)
+            $$;
+        "#;
+        Spi::run(definition);
+        let result = Spi::get_one::<i32>("SELECT link_section();\n");
         assert_eq!(Some(1), result);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -504,9 +504,7 @@ mod tests {
     #[pg_test]
     #[search_path(@extschema@)]
     #[should_panic]
-    #[ignore]
     fn plrust_block_unsafe_plutonium() {
-        // TODO: PL/Rust should defeat the latest in cutting-edge `unsafe` obfuscation tech
         let definition = r#"
             CREATE FUNCTION super_safe()
             RETURNS text AS

--- a/src/user_crate/crate_variant.rs
+++ b/src/user_crate/crate_variant.rs
@@ -5,6 +5,7 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 
 #[must_use]
+#[derive(Clone)]
 pub(crate) enum CrateVariant {
     Function {
         arguments: Vec<syn::FnArg>,

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -407,9 +407,8 @@ mod tests {
 
             let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                #![deny(unsafe_op_in_unsafe_fn)]
+                #![forbid(unsafe_code)]
                 use pgx::prelude::*;
-                #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())
                 }

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -3,6 +3,7 @@ mod state_built;
 mod state_generated;
 mod state_loaded;
 mod state_provisioned;
+mod state_validated;
 mod target;
 
 use crate_variant::CrateVariant;
@@ -10,6 +11,7 @@ pub(crate) use state_built::StateBuilt;
 pub(crate) use state_generated::StateGenerated;
 pub(crate) use state_loaded::StateLoaded;
 pub(crate) use state_provisioned::StateProvisioned;
+pub(crate) use state_validated::StateValidated;
 
 use crate::PlRustError;
 #[cfg(feature = "verify")]

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -104,10 +104,7 @@ impl UserCrate<StateValidated> {
             crate_dir = %self.0.crate_dir().display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub fn build(
-        self,
-        target_dir: &Path,
-    ) -> eyre::Result<(UserCrate<StateBuilt>, Output)> {
+    pub fn build(self, target_dir: &Path) -> eyre::Result<(UserCrate<StateBuilt>, Output)> {
         self.0
             .build(target_dir)
             .map(|(state, output)| (UserCrate(state), output))

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -112,10 +112,6 @@ impl UserCrate<StateValidated> {
             .build(target_dir)
             .map(|(state, output)| (UserCrate(state), output))
     }
-
-    pub(crate) fn crate_dir(&self) -> &Path {
-        self.0.crate_dir()
-    }
 }
 
 impl UserCrate<StateBuilt> {

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -106,11 +106,10 @@ impl UserCrate<StateValidated> {
         ))]
     pub fn build(
         self,
-        pg_config: PathBuf,
         target_dir: &Path,
     ) -> eyre::Result<(UserCrate<StateBuilt>, Output)> {
         self.0
-            .build(pg_config, target_dir)
+            .build(target_dir)
             .map(|(state, output)| (UserCrate(state), output))
     }
 

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -456,7 +456,7 @@ mod tests {
 
             let (validated, _output) = provisioned.validate(pg_config, &target_dir)?;
 
-            let (built, _output) = validated.build(pg_config, &target_dir)?;
+            let (built, _output) = validated.build(&target_dir)?;
 
             let _shared_object = built.shared_object();
 

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -332,11 +332,10 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let generated_lib_rs = generated.lib_rs()?;
+            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                #![deny(unsafe_op_in_unsafe_fn)]
+                #![forbid(unsafe_code)]
                 use pgx::prelude::*;
-                #[pg_extern]
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())
                 }
@@ -397,11 +396,10 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let generated_lib_rs = generated.lib_rs()?;
+            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                #![deny(unsafe_op_in_unsafe_fn)]
+                #![forbid(unsafe_code)]
                 use pgx::prelude::*;
-                #[pg_extern]
                 fn #symbol_ident(val: Option<i32>) -> Option<i64> {
                     val.map(|v| v as i64)
                 }
@@ -462,11 +460,10 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let generated_lib_rs = generated.lib_rs()?;
+            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                #![deny(unsafe_op_in_unsafe_fn)]
+                #![forbid(unsafe_code)]
                 use pgx::prelude::*;
-                #[pg_extern]
                 fn #symbol_ident(val: &str) -> Option<::pgx::iter::SetOfIterator<Option<String>>> {
                     Some(std::iter::repeat(val).take(5))
                 }
@@ -518,11 +515,10 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let generated_lib_rs = generated.lib_rs()?;
+            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
             let fixture_lib_rs = parse_quote! {
-                #![deny(unsafe_op_in_unsafe_fn)]
+                #![forbid(unsafe_code)]
                 use pgx::prelude::*;
-                #[pg_trigger]
                 fn #symbol_ident(
                     trigger: &::pgx::PgTrigger,
                 ) -> ::core::result::Result<

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -268,7 +268,7 @@ impl StateGenerated {
             crate_name,
             crate_dir,
             user_fn,
-            self.variant,
+            self.variant.clone(),
         ))
     }
 

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -85,17 +85,16 @@ impl StateGenerated {
         })
     }
     pub(crate) fn crate_name(&self) -> String {
-        let mut crate_name = crate::plrust::crate_name(self.db_oid, self.fn_oid);
+        let mut _crate_name = crate::plrust::crate_name(self.db_oid, self.fn_oid);
         #[cfg(any(
             all(target_os = "macos", target_arch = "x86_64"),
             feature = "force_enable_x86_64_darwin_generations"
         ))]
         {
-            let next = crate::generation::next_generation(&crate_name, true).unwrap_or_default();
-
-            crate_name.push_str(&format!("_{}", next));
+            let next = crate::generation::next_generation(&_crate_name, true).unwrap_or_default();
+            _crate_name.push_str(&format!("_{}", next));
         }
-        crate_name
+        _crate_name
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -129,7 +129,7 @@ impl StateGenerated {
                 let user_fn: syn::ItemFn = syn::parse2(quote! {
                     fn #symbol_ident(
                         trigger: &::pgx::PgTrigger,
-                    ) -> core::result::Result<
+                    ) -> ::core::result::Result<
                         ::pgx::heap_tuple::PgHeapTuple<'_, impl ::pgx::WhoAllocated<::pgx::pg_sys::HeapTupleData>>,
                         Box<dyn std::error::Error>,
                     > #user_code

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -139,7 +139,7 @@ impl StateGenerated {
             }
         };
 
-        skeleton.items.push(user_fn.into());
+        skeleton.items.push(user_fn.clone().into());
         Ok((user_fn, skeleton))
     }
 

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -57,7 +57,7 @@ impl StateProvisioned {
             use pgx::prelude::*;
         );
 
-        let crate_name = self.crate_name;
+        let crate_name = &self.crate_name;
         let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
         tracing::trace!(symbol_name = %crate_name, "Generating `lib.rs` for build step");
@@ -107,7 +107,7 @@ impl StateProvisioned {
         command.arg("check");
         command.arg("--target");
         command.arg(target_str);
-        command.env("PGX_PG_CONFIG_PATH", pg_config);
+        command.env("PGX_PG_CONFIG_PATH", &pg_config);
         command.env("CARGO_TARGET_DIR", &target_dir);
         command.env("RUSTFLAGS", "-Clink-args=-Wl,-undefined,dynamic_lookup");
 
@@ -116,7 +116,7 @@ impl StateProvisioned {
         if output.status.success() {
             use std::env::consts::DLL_SUFFIX;
 
-            let crate_name = self.crate_name;
+            let crate_name = self.crate_name.clone();
 
             // rebuild code:
             let lib_rs = self.unsafe_lib_rs()?;
@@ -145,7 +145,8 @@ impl StateProvisioned {
                     self.db_oid,
                     self.fn_oid,
                     self.crate_name,
-                    self.crate_dir
+                    self.crate_dir,
+                    pg_config,
                 ),
                 output,
             ))

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -1,14 +1,19 @@
 use crate::{
-    user_crate::{target, CrateState, StateBuilt},
+    user_crate::{target, StateBuilt},
     PlRustError,
 };
 use color_eyre::{Section, SectionExt};
 use eyre::{eyre, WrapErr};
-use pgx::pg_sys;
 use std::{
     path::{Path, PathBuf},
     process::{Command, Output},
 };
+use crate::pgproc::PgProc;
+use crate::{
+    user_crate::{parse_source_and_deps, CrateState, CrateVariant, StateValidated},
+};
+use pgx::{pg_sys, PgOid};
+use quote::quote;
 
 #[must_use]
 pub(crate) struct StateProvisioned {
@@ -17,6 +22,8 @@ pub(crate) struct StateProvisioned {
     fn_oid: pg_sys::Oid,
     crate_name: String,
     crate_dir: PathBuf,
+    user_fn: syn::ItemFn,
+    variant: CrateVariant,
 }
 
 impl CrateState for StateProvisioned {}
@@ -29,6 +36,8 @@ impl StateProvisioned {
         fn_oid: pg_sys::Oid,
         crate_name: String,
         crate_dir: PathBuf,
+        user_fn: syn::ItemFn,
+        variant: CrateVariant,
     ) -> Self {
         Self {
             pg_proc_xmin,
@@ -36,8 +45,46 @@ impl StateProvisioned {
             fn_oid,
             crate_name,
             crate_dir,
+            user_fn,
+            variant,
         }
     }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
+    pub(crate) fn unsafe_lib_rs(&self) -> eyre::Result<syn::File> {
+        let mut skeleton: syn::File = syn::parse_quote!(
+            #![forbid(unsafe_op_in_unsafe_fn)]
+            use pgx::prelude::*;
+        );
+
+        let crate_name = self.crate_name;
+        let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
+
+        tracing::trace!(symbol_name = %crate_name, "Generating `lib.rs` for build step");
+
+        let mut user_fn = self.user_fn.clone();
+        match &self.variant {
+            CrateVariant::Function {
+                ref arguments,
+                ref return_type,
+                ..
+            } => {
+                user_fn.attrs.push(syn::parse_quote! {
+                    #[pg_extern]
+                });
+            }
+            CrateVariant::Trigger => {
+                user_fn.attrs.push(syn::parse_quote! {
+                    #[pg_trigger]
+                });
+            }
+        };
+
+        skeleton.items.push(user_fn.into());
+        Ok(skeleton)
+    }
+
+
     #[tracing::instrument(
         level = "debug",
         skip_all,
@@ -47,18 +94,17 @@ impl StateProvisioned {
             crate_dir = %self.crate_dir.display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub(crate) fn build(
+    pub(crate) fn validate(
         self,
         pg_config: PathBuf,
         target_dir: &Path,
-    ) -> eyre::Result<(StateBuilt, Output)> {
+    ) -> eyre::Result<(StateValidated, Output)> {
         let mut command = Command::new("cargo");
         let target = target::tuple()?;
         let target_str = &target;
 
         command.current_dir(&self.crate_dir);
-        command.arg("rustc");
-        command.arg("--release");
+        command.arg("check");
         command.arg("--target");
         command.arg(target_str);
         command.env("PGX_PG_CONFIG_PATH", pg_config);
@@ -71,6 +117,13 @@ impl StateProvisioned {
             use std::env::consts::DLL_SUFFIX;
 
             let crate_name = self.crate_name;
+
+            // rebuild code:
+            let lib_rs = self.unsafe_lib_rs()?;
+            let lib_rs_path = self.crate_dir.join("src/lib.rs");
+            std::fs::write(&lib_rs_path, &prettyplease::unparse(&lib_rs))
+                .wrap_err("Writing generated `lib.rs`")?;
+
 
             #[cfg(any(
                 all(target_os = "macos", target_arch = "x86_64"),
@@ -86,18 +139,13 @@ impl StateProvisioned {
                 crate_name
             };
 
-            let built_shared_object_name = &format!("lib{crate_name}{DLL_SUFFIX}");
-            let built_shared_object = target_dir
-                .join(target_str)
-                .join("release")
-                .join(&built_shared_object_name);
-
             Ok((
-                StateBuilt::new(
+                StateValidated::new(
                     self.pg_proc_xmin,
                     self.db_oid,
                     self.fn_oid,
-                    built_shared_object,
+                    self.crate_name,
+                    self.crate_dir
                 ),
                 output,
             ))

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -1,19 +1,11 @@
-use crate::{
-    user_crate::{target, StateBuilt},
-    PlRustError,
-};
+use crate::user_crate::{target, CrateState, CrateVariant, StateValidated, PlRustError};
 use color_eyre::{Section, SectionExt};
 use eyre::{eyre, WrapErr};
+use pgx::pg_sys;
 use std::{
     path::{Path, PathBuf},
     process::{Command, Output},
 };
-use crate::pgproc::PgProc;
-use crate::{
-    user_crate::{parse_source_and_deps, CrateState, CrateVariant, StateValidated},
-};
-use pgx::{pg_sys, PgOid};
-use quote::quote;
 
 #[must_use]
 pub(crate) struct StateProvisioned {
@@ -114,8 +106,6 @@ impl StateProvisioned {
         let output = command.output().wrap_err("`cargo` execution failure")?;
 
         if output.status.success() {
-            use std::env::consts::DLL_SUFFIX;
-
             let crate_name = self.crate_name.clone();
 
             // rebuild code:

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -50,15 +50,11 @@ impl StateProvisioned {
         );
 
         let crate_name = &self.crate_name;
-        let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
-
         tracing::trace!(symbol_name = %crate_name, "Generating `lib.rs` for build step");
 
         let mut user_fn = self.user_fn.clone();
         match &self.variant {
             CrateVariant::Function {
-                ref arguments,
-                ref return_type,
                 ..
             } => {
                 user_fn.attrs.push(syn::parse_quote! {
@@ -134,7 +130,7 @@ impl StateProvisioned {
                     self.pg_proc_xmin,
                     self.db_oid,
                     self.fn_oid,
-                    self.crate_name,
+                    crate_name,
                     self.crate_dir,
                     pg_config,
                 ),

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -53,7 +53,7 @@ impl StateProvisioned {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
     pub(crate) fn unsafe_lib_rs(&self) -> eyre::Result<syn::File> {
         let mut skeleton: syn::File = syn::parse_quote!(
-            #![forbid(unsafe_op_in_unsafe_fn)]
+            #![deny(unsafe_op_in_unsafe_fn)]
             use pgx::prelude::*;
         );
 

--- a/src/user_crate/state_provisioned.rs
+++ b/src/user_crate/state_provisioned.rs
@@ -1,4 +1,4 @@
-use crate::user_crate::{target, CrateState, CrateVariant, StateValidated, PlRustError};
+use crate::user_crate::{target, CrateState, CrateVariant, PlRustError, StateValidated};
 use color_eyre::{Section, SectionExt};
 use eyre::{eyre, WrapErr};
 use pgx::pg_sys;
@@ -54,9 +54,7 @@ impl StateProvisioned {
 
         let mut user_fn = self.user_fn.clone();
         match &self.variant {
-            CrateVariant::Function {
-                ..
-            } => {
+            CrateVariant::Function { .. } => {
                 user_fn.attrs.push(syn::parse_quote! {
                     #[pg_extern]
                 });
@@ -71,7 +69,6 @@ impl StateProvisioned {
         skeleton.items.push(user_fn.into());
         Ok(skeleton)
     }
-
 
     #[tracing::instrument(
         level = "debug",
@@ -109,7 +106,6 @@ impl StateProvisioned {
             let lib_rs_path = self.crate_dir.join("src/lib.rs");
             std::fs::write(&lib_rs_path, &prettyplease::unparse(&lib_rs))
                 .wrap_err("Writing generated `lib.rs`")?;
-
 
             #[cfg(any(
                 all(target_os = "macos", target_arch = "x86_64"),

--- a/src/user_crate/state_validated.rs
+++ b/src/user_crate/state_validated.rs
@@ -17,6 +17,7 @@ pub(crate) struct StateValidated {
     fn_oid: pg_sys::Oid,
     crate_name: String,
     crate_dir: PathBuf,
+    pg_config: PathBuf,
 }
 
 impl CrateState for StateValidated {}
@@ -29,6 +30,7 @@ impl StateValidated {
         fn_oid: pg_sys::Oid,
         crate_name: String,
         crate_dir: PathBuf,
+        pg_config: PathBuf,
     ) -> Self {
         Self {
             pg_proc_xmin,
@@ -36,6 +38,7 @@ impl StateValidated {
             fn_oid,
             crate_name,
             crate_dir,
+            pg_config,
         }
     }
 
@@ -50,7 +53,6 @@ impl StateValidated {
         ))]
     pub(crate) fn build(
         self,
-        pg_config: PathBuf,
         target_dir: &Path,
     ) -> eyre::Result<(StateBuilt, Output)> {
         let mut command = Command::new("cargo");
@@ -62,7 +64,7 @@ impl StateValidated {
         command.arg("--release");
         command.arg("--target");
         command.arg(target_str);
-        command.env("PGX_PG_CONFIG_PATH", pg_config);
+        command.env("PGX_PG_CONFIG_PATH", self.pg_config);
         command.env("CARGO_TARGET_DIR", &target_dir);
         command.env("RUSTFLAGS", "-Clink-args=-Wl,-undefined,dynamic_lookup");
 

--- a/src/user_crate/state_validated.rs
+++ b/src/user_crate/state_validated.rs
@@ -1,0 +1,133 @@
+use crate::{
+    user_crate::{target, CrateState, StateBuilt},
+    PlRustError,
+};
+use color_eyre::{Section, SectionExt};
+use eyre::{eyre, WrapErr};
+use pgx::pg_sys;
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+#[must_use]
+pub(crate) struct StateValidated {
+    pg_proc_xmin: pg_sys::TransactionId,
+    db_oid: pg_sys::Oid,
+    fn_oid: pg_sys::Oid,
+    crate_name: String,
+    crate_dir: PathBuf,
+}
+
+impl CrateState for StateValidated {}
+
+impl StateValidated {
+    #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %db_oid, fn_oid = %fn_oid, crate_name = %crate_name, crate_dir = %crate_dir.display()))]
+    pub(crate) fn new(
+        pg_proc_xmin: pg_sys::TransactionId,
+        db_oid: pg_sys::Oid,
+        fn_oid: pg_sys::Oid,
+        crate_name: String,
+        crate_dir: PathBuf,
+    ) -> Self {
+        Self {
+            pg_proc_xmin,
+            db_oid,
+            fn_oid,
+            crate_name,
+            crate_dir,
+        }
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(
+            db_oid = %self.db_oid,
+            fn_oid = %self.fn_oid,
+            crate_dir = %self.crate_dir.display(),
+            target_dir = tracing::field::display(target_dir.display()),
+        ))]
+    pub(crate) fn build(
+        self,
+        pg_config: PathBuf,
+        target_dir: &Path,
+    ) -> eyre::Result<(StateBuilt, Output)> {
+        let mut command = Command::new("cargo");
+        let target = target::tuple()?;
+        let target_str = &target;
+
+        command.current_dir(&self.crate_dir);
+        command.arg("rustc");
+        command.arg("--release");
+        command.arg("--target");
+        command.arg(target_str);
+        command.env("PGX_PG_CONFIG_PATH", pg_config);
+        command.env("CARGO_TARGET_DIR", &target_dir);
+        command.env("RUSTFLAGS", "-Clink-args=-Wl,-undefined,dynamic_lookup");
+
+        let output = command.output().wrap_err("`cargo` execution failure")?;
+
+        if output.status.success() {
+            use std::env::consts::DLL_SUFFIX;
+
+            let crate_name = self.crate_name;
+
+            #[cfg(any(
+                all(target_os = "macos", target_arch = "x86_64"),
+                feature = "force_enable_x86_64_darwin_generations"
+            ))]
+            let crate_name = {
+                let mut crate_name = crate_name;
+                let next = crate::generation::next_generation(&crate_name, true)
+                    .map(|gen_num| gen_num)
+                    .unwrap_or_default();
+
+                crate_name.push_str(&format!("_{}", next));
+                crate_name
+            };
+
+            let built_shared_object_name = &format!("lib{crate_name}{DLL_SUFFIX}");
+            let built_shared_object = target_dir
+                .join(target_str)
+                .join("release")
+                .join(&built_shared_object_name);
+
+            Ok((
+                StateBuilt::new(
+                    self.pg_proc_xmin,
+                    self.db_oid,
+                    self.fn_oid,
+                    built_shared_object,
+                ),
+                output,
+            ))
+        } else {
+            let stdout =
+                String::from_utf8(output.stdout).wrap_err("`cargo`'s stdout was not  UTF-8")?;
+            let stderr =
+                String::from_utf8(output.stderr).wrap_err("`cargo`'s stderr was not  UTF-8")?;
+
+            Err(eyre!(PlRustError::CargoBuildFail)
+                .section(stdout.header("`cargo build` stdout:"))
+                .section(stderr.header("`cargo build` stderr:"))
+                .with_section(|| {
+                    std::fs::read_to_string(&self.crate_dir.join("src").join("lib.rs"))
+                        .wrap_err("Writing generated `lib.rs`")
+                        .expect("Reading generated `lib.rs` to output during error")
+                        .header("Source Code:")
+                }))?
+        }
+    }
+
+    pub(crate) fn fn_oid(&self) -> pg_sys::Oid {
+        self.fn_oid
+    }
+
+    pub(crate) fn db_oid(&self) -> pg_sys::Oid {
+        self.db_oid
+    }
+    pub(crate) fn crate_dir(&self) -> &Path {
+        &self.crate_dir
+    }
+}

--- a/src/user_crate/state_validated.rs
+++ b/src/user_crate/state_validated.rs
@@ -51,10 +51,7 @@ impl StateValidated {
             crate_dir = %self.crate_dir.display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub(crate) fn build(
-        self,
-        target_dir: &Path,
-    ) -> eyre::Result<(StateBuilt, Output)> {
+    pub(crate) fn build(self, target_dir: &Path) -> eyre::Result<(StateBuilt, Output)> {
         let mut command = Command::new("cargo");
         let target = target::tuple()?;
         let target_str = &target;


### PR DESCRIPTION
This PR adds code sufficient to catch the usage of `#[no_mangle]`. Note that deploying PL/Rust with the given Rust toolchain currently indicated by our `rust-toolchain.toml` will not in fact catch `#[link_section]`, despite the branch name. That requires an upgrade to a more recent version of Rust, which is incompatible with use with `postgrestd`.