### PR TITLE
upgrade to pgx 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  CARGO_PGX_VERSION: "0.6.0-alpha.1"
+  CARGO_PGX_VERSION: "0.6.0"
   # CARGO_LOG: cargo::core::compiler::fingerprint=info # Uncomment this to output compiler fingerprint info
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9d4197911a62aa8f44512501414756466c9aeea33e18578f7658ef53c1f155"
+checksum = "7652ea68f83ee6308d165826c0fde48d439bc6176b6ff91d202158840e58951f"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c543fd86fa8b496735d78e4cefd10ca2d275365e5fe4da532970f3b722946d8"
+checksum = "893a2aa60e5172feea53db8ec17c5cd0e8c70aa68879fda4c8798fb74c67d7a0"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba575fca3635dc2e145f1bc204c4a10e5567b96bede1a884eeab6a998516fd2"
+checksum = "604b0165c023ac7fa26d558b89caad6ce8e947dc37654c00356a5e72022e1db5"
 dependencies = [
  "dirs",
  "eyre",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc7628aa959b1e928fe9289c517e1b1e10d7ca8ad4926792fa86b62b997f9c1"
+checksum = "b56db285d63898b8b13ceeea3c63d269a46bdd302662312a120c743a5bf0036b"
 dependencies = [
  "bindgen",
  "eyre",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d1b58ee002386113e483a1d9fd917b9e185105cbf0e1e787a0f093a026e26"
+checksum = "0b7359545fdddf10242c87f100502268ad155a9cd89c96b69813e6edd80863ac"
 dependencies = [
  "eyre",
  "libc",
@@ -980,16 +980,15 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shutdown_hooks",
  "thiserror",
  "time",
 ]
 
 [[package]]
 name = "pgx-utils"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66c2a5e23d2bdbef29ebed4bf66fa844ec77e62baa1b56c64e800fbf507a798"
+checksum = "1c63119438e1d7f44333908bacf40ec1aa1c6aaac5d8f5023d213a12f28f430e"
 dependencies = [
  "atty",
  "convert_case",
@@ -1209,11 +1208,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1221,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1423,9 +1421,9 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -1442,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1453,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -1487,12 +1485,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "shutdown_hooks"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6057adedbec913419c92996f395ba69931acbd50b7d56955394cd3f7bedbfa45"
 
 [[package]]
 name = "siphasher"
@@ -1561,9 +1553,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ cfg-if = "1" # platform conditional helper
 once_cell = "1.7.2" # polyfills a nightly feature
 
 # pgx core details
-pgx = { version = "0.6.0-alpha.1" }
-pgx-pg-config = { version = "0.6.0-alpha.1" }
+pgx = { version = "0.6.0" }
+pgx-pg-config = { version = "0.6.0" }
 
 # language handler support
 libloading = "0.7.2"
@@ -57,7 +57,7 @@ proc-macro2 = "1"
 geiger = { version = "0.4", optional = true } # unsafe detection
 
 [dev-dependencies]
-pgx-tests = { version = "0.6.0-alpha.1" }
+pgx-tests = { version = "0.6.0" }
 tempdir = "0.3.7"
 once_cell = "1.7.2"
 toml = "0.5.8"

--- a/build
+++ b/build
@@ -11,7 +11,7 @@ cargo update -p pgx
 cargo fetch
 if [ "$CI" != true ]; then
     cargo install cargo-pgx \
-    --version "0.6.0-alpha.1" \
+    --version "0.6.0" \
     --locked # use the Cargo.lock in the pgx repo
 fi
 # Don't need to run cargo pgx init: user might already have set it up,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.65.0"
 components = [ "rustfmt" ]
 targets = [ ]
 profile = "minimal"

--- a/src/user_crate/mod.rs
+++ b/src/user_crate/mod.rs
@@ -321,7 +321,7 @@ mod tests {
                 crate-type = ["cdylib"]
 
                 [dependencies]
-                pgx = { version = "0.6.0-alpha.1", features = ["plrust"] }
+                pgx = { version = "0.6.0", features = ["plrust"] }
                 pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
                 /* User deps added here */
 

--- a/src/user_crate/state_generated.rs
+++ b/src/user_crate/state_generated.rs
@@ -185,7 +185,7 @@ impl StateGenerated {
                     crate-type = ["cdylib"]
 
                     [dependencies]
-                    pgx =  { version = "0.6.0-alpha.1", features = ["plrust"] }
+                    pgx =  { version = "0.6.0", features = ["plrust"] }
                     pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
                     /* User deps added here */
 


### PR DESCRIPTION
This upgrades plrust to the newly released pgx v0.6.0. 

It also changes the rust-toolchain channel to rust 1.65 because 1.61 ain't gonna work anymore