### PR TITLE
use `pg_identify_object()` value as the pkey for `plrust.plrust_proc`

### DIFF
--- a/plrust/src/plrust_proc.rs
+++ b/plrust/src/plrust_proc.rs
@@ -140,7 +140,8 @@ fn get_fn_identity_datum(pg_proc_oid: pg_sys::Oid) -> (PgOid, Option<pg_sys::Dat
     let result = (PgBuiltInOids::TEXTOID.oid(), identity_str.into_datum());
 
     unsafe {
-        // SAFETY: identity_ptr was previously proven valid
+        // SAFETY: identity_ptr was previously proven valid and
+        // identity_str was reallocated elsewhere in Postgres
         pg_sys::pfree(identity_ptr.cast());
     }
 

--- a/plrust/src/plrust_proc.rs
+++ b/plrust/src/plrust_proc.rs
@@ -111,7 +111,7 @@ fn pkey_datums(pg_proc_oid: pg_sys::Oid) -> Vec<(PgOid, Option<pg_sys::Datum>)> 
 // helper function to build the function identity (oid, value) datum
 fn get_fn_identity_datum(pg_proc_oid: pg_sys::Oid) -> (PgOid, Option<pg_sys::Datum>) {
     let oa = pg_sys::ObjectAddress {
-        classId: pg_sys::ProcedureRelationId,
+        classId: pg_sys::ProcedureRelationId, // the "oid" of Postgres' `pg_catalog.pg_proc` table
         objectId: pg_proc_oid,
         objectSubId: 0,
     };

--- a/plrust/src/plrust_proc.rs
+++ b/plrust/src/plrust_proc.rs
@@ -118,15 +118,15 @@ fn get_fn_identity_datum(pg_proc_oid: pg_sys::Oid) -> (PgOid, Option<pg_sys::Dat
     let identity_ptr = unsafe {
         #[cfg(feature = "pg13")]
         {
-            // SAFETY:  getObjectIdentity will raise an ERROR if theObjectAddress we created doesn't
-            // exist, otherwise returning a properly palloc'd pointer
+            // SAFETY:  getObjectIdentity will raise an ERROR if the ObjectAddress we created doesn't
+            // exist, otherwise it returns a properly palloc'd pointer
             pg_sys::getObjectIdentity(&oa as *const _)
         }
 
         #[cfg(not(feature = "pg13"))]
         {
             // SAFETY:  by setting "missing_ok" to false, getObjectIdentity will raise an ERROR if the
-            // ObjectAddress we created doesn't exist, otherwise returning a properly palloc'd pointer
+            // ObjectAddress we created doesn't exist, otherwise it returns a properly palloc'd pointer
             pg_sys::getObjectIdentity(&oa as *const _, false)
         }
     };

--- a/plrust/src/plrust_proc.rs
+++ b/plrust/src/plrust_proc.rs
@@ -116,9 +116,19 @@ fn get_fn_identity_datum(pg_proc_oid: pg_sys::Oid) -> (PgOid, Option<pg_sys::Dat
         objectSubId: 0,
     };
     let identity_ptr = unsafe {
-        // SAFETY:  by setting "missing_ok_ to false, getObjectIdentity will raise an ERROR if the
-        // ObjectAddress we created doesn't exist, otherwise returning a properly palloc'd pointer
-        pg_sys::getObjectIdentity(&oa as *const _, false)
+        #[cfg(feature = "pg13")]
+        {
+            // SAFETY:  getObjectIdentity will raise an ERROR if theObjectAddress we created doesn't
+            // exist, otherwise returning a properly palloc'd pointer
+            pg_sys::getObjectIdentity(&oa as *const _)
+        }
+
+        #[cfg(not(feature = "pg13"))]
+        {
+            // SAFETY:  by setting "missing_ok" to false, getObjectIdentity will raise an ERROR if the
+            // ObjectAddress we created doesn't exist, otherwise returning a properly palloc'd pointer
+            pg_sys::getObjectIdentity(&oa as *const _, false)
+        }
     };
     let identity_str = unsafe {
         // SAFETY:  Postgres has given us a valid, albeit palloc'd, cstring as the result of getObjectIdentity

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -752,11 +752,17 @@ mod tests {
         )?
         .expect("failed to lookup function oid");
 
+        let procedure_id = pg_sys::ProcedureRelationId;
+        let identity = Spi::get_one::<pg_sys::Oid>(&format!(
+            "SELECT identity from pg_identify_object({procedure_id}, {oid}, 0)"
+        ))
+        .expect("call to pg_identify_object returned NULL");
+
         Spi::run("DROP FUNCTION drop_function");
 
         let procedure_id = pg_sys::ProcedureRelationId;
         let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
-            "SELECT id FROM plrust.plrust_proc WHERE id = (select identity from pg_identify_object({procedure_id}, {oid}, 0))"
+            "SELECT id FROM plrust.plrust_proc WHERE id = '{identity}'"
         ));
         assert_eq!(our_id, Err(spi::Error::InvalidPosition));
         Ok(())
@@ -778,11 +784,15 @@ mod tests {
         )?
         .expect("failed to lookup function oid");
 
-        Spi::run("DROP SCHEMA to_drop CASCADE");
-
         let procedure_id = pg_sys::ProcedureRelationId;
+        let identity = Spi::get_one::<pg_sys::Oid>(&format!(
+            "SELECT identity from pg_identify_object({procedure_id}, {oid}, 0)"
+        ))
+        .expect("call to pg_identify_object returned NULL");
+
+        Spi::run("DROP SCHEMA to_drop CASCADE")?;
         let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
-            "SELECT id FROM plrust.plrust_proc WHERE id = (select identity from pg_identify_object({procedure_id}, {oid}, 0))"
+            "SELECT id FROM plrust.plrust_proc WHERE id = '{identity}'"
         ));
         assert_eq!(our_id, Err(spi::Error::InvalidPosition));
         Ok(())

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -753,15 +753,14 @@ mod tests {
         .expect("failed to lookup function oid");
 
         let procedure_id = pg_sys::ProcedureRelationId;
-        let identity = Spi::get_one::<pg_sys::Oid>(&format!(
+        let identity = Spi::get_one::<String>(&format!(
             "SELECT identity from pg_identify_object({procedure_id}, {oid}, 0)"
-        ))
+        ))?
         .expect("call to pg_identify_object returned NULL");
 
-        Spi::run("DROP FUNCTION drop_function");
+        Spi::run("DROP FUNCTION drop_function")?;
 
-        let procedure_id = pg_sys::ProcedureRelationId;
-        let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
+        let our_id = Spi::get_one::<String>(&format!(
             "SELECT id FROM plrust.plrust_proc WHERE id = '{identity}'"
         ));
         assert_eq!(our_id, Err(spi::Error::InvalidPosition));
@@ -785,13 +784,13 @@ mod tests {
         .expect("failed to lookup function oid");
 
         let procedure_id = pg_sys::ProcedureRelationId;
-        let identity = Spi::get_one::<pg_sys::Oid>(&format!(
+        let identity = Spi::get_one::<String>(&format!(
             "SELECT identity from pg_identify_object({procedure_id}, {oid}, 0)"
-        ))
+        ))?
         .expect("call to pg_identify_object returned NULL");
 
         Spi::run("DROP SCHEMA to_drop CASCADE")?;
-        let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
+        let our_id = Spi::get_one::<String>(&format!(
             "SELECT id FROM plrust.plrust_proc WHERE id = '{identity}'"
         ));
         assert_eq!(our_id, Err(spi::Error::InvalidPosition));

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -751,9 +751,12 @@ mod tests {
             "SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'drop_function'",
         )?
         .expect("failed to lookup function oid");
-        Spi::run("DROP FUNCTION drop_function")?;
+
+        Spi::run("DROP FUNCTION drop_function");
+
+        let procedure_id = pg_sys::ProcedureRelationId;
         let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
-            "SELECT id FROM plrust.plrust_proc WHERE id = {oid}"
+            "SELECT id FROM plrust.plrust_proc WHERE id = (select identity from pg_identify_object({procedure_id}, {oid}, 0))"
         ));
         assert_eq!(our_id, Err(spi::Error::InvalidPosition));
         Ok(())
@@ -774,9 +777,12 @@ mod tests {
             "SELECT oid FROM pg_catalog.pg_proc WHERE oid = 'to_drop.drop_function'::regproc::oid",
         )?
         .expect("failed to lookup function oid");
-        Spi::run("DROP SCHEMA to_drop CASCADE")?;
+
+        Spi::run("DROP SCHEMA to_drop CASCADE");
+
+        let procedure_id = pg_sys::ProcedureRelationId;
         let our_id = Spi::get_one::<pg_sys::Oid>(&format!(
-            "SELECT id FROM plrust.plrust_proc WHERE id = {oid}"
+            "SELECT id FROM plrust.plrust_proc WHERE id = (select identity from pg_identify_object({procedure_id}, {oid}, 0))"
         ));
         assert_eq!(our_id, Err(spi::Error::InvalidPosition));
         Ok(())


### PR DESCRIPTION
See the comments that @JohnHVancouver made on his PR #140, but this is the right way to do this.  Doesn't require going through SPI to lookup the object identifier.