### PR TITLE
Introduce a `trusted-pgx` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "trusted-pgx"
+version = "0.0.0"
+dependencies = [
+ "pgx",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "plrust",
+    "trusted-pgx",
 ]
 
 [profile.dev.build-override]

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -285,7 +285,7 @@ pub(crate) fn cargo_toml_template(crate_name: &str, version_feature: &str) -> to
         crate-type = ["cdylib"]
 
         [dependencies]
-        pgx =  { git = "https://github.com/tcdi/plrust/trusted-pgx", branch = "trusted-pgx", package = "trusted-pgx" }
+        pgx =  { git = "https://github.com/tcdi/plrust", branch = "trusted-pgx", package = "trusted-pgx" }
         // pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
 
         /* User deps added here */

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -375,10 +375,10 @@ fn check_dependencies_against_allowed(dependencies: &toml::value::Table) -> eyre
 mod tests {
     use pgx::*;
 
+    use crate::user_crate::crating::cargo_toml_template;
     use crate::user_crate::*;
     use quote::quote;
     use syn::parse_quote;
-    use toml::toml;
 
     #[pg_test]
     fn full_workflow() {
@@ -456,30 +456,8 @@ mod tests {
 
             let generated_cargo_toml = generated.cargo_toml()?;
             let version_feature = format!("pgx/pg{}", pgx::pg_sys::get_pg_major_version_num());
-            let fixture_cargo_toml = toml! {
-                [package]
-                edition = "2021"
-                name = crate_name
-                version = "0.0.0"
+            let fixture_cargo_toml = cargo_toml_template(&crate_name, &version_feature);
 
-                [features]
-                default = [version_feature]
-
-                [lib]
-                crate-type = ["cdylib"]
-
-                [dependencies]
-                pgx = { git = "https://github.com/tcdi/pgx", branch = "develop" }
-                // pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
-                /* User deps added here */
-
-                [profile.release]
-                debug-assertions = true
-                codegen-units = 1_usize
-                lto = "fat"
-                opt-level = 3_usize
-                panic = "unwind"
-            };
             assert_eq!(
                 toml::to_string(&generated_cargo_toml)?,
                 toml::to_string(&fixture_cargo_toml)?,

--- a/trusted-pgx/Cargo.toml
+++ b/trusted-pgx/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "trusted-pgx"
+version = "0.0.0"
+authors = ["TCDI <opensource@tcdi.com>"]
+edition = "2021"
+license = "PostgreSQL Open Source License"
+description = "Minimal set of `pgx` rexports for plrust, which the authors have deemed trusted"
+homepage = "https://github.com/tcdi/plrust/"
+repository = "https://github.com/tcdi/plrust/"
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+pg13 = ["pgx/pg13"]
+pg14 = ["pgx/pg14"]
+pg15 = ["pgx/pg15"]
+
+[dependencies]
+pgx = { git = "https://github.com/tcdi/pgx", branch = "develop", features = [ "no-schema-generation", "plrust" ], default-features = false }
+#pgx = { path = "/Users/e_ridge/_work/pgx/pgx", features = [ "no-schema-generation", "plrust" ], default-features = false }

--- a/trusted-pgx/src/lib.rs
+++ b/trusted-pgx/src/lib.rs
@@ -1,0 +1,90 @@
+pub mod prelude {
+    pub use super::*;
+}
+
+pub use ::pgx::{debug1, debug2, debug3, debug4, debug5, ereport, error, info, notice, warning};
+
+pub use datum::*;
+pub mod datum {
+    pub use ::pgx::datum::{
+        AnyNumeric, Date, FromDatum, IntoDatum, Json, JsonB, Time, TimeWithTimeZone, Timestamp,
+        TimestampWithTimeZone,
+    };
+}
+
+pub mod fcinfo {
+    pub use ::pgx::fcinfo::pg_getarg;
+    pub use ::pgx::fcinfo::pg_return_null;
+    pub use ::pgx::fcinfo::pg_return_void;
+    pub use ::pgx::fcinfo::srf_first_call_init;
+    pub use ::pgx::fcinfo::srf_is_first_call;
+    pub use ::pgx::fcinfo::srf_per_call_setup;
+    pub use ::pgx::fcinfo::srf_return_done;
+    pub use ::pgx::fcinfo::srf_return_next;
+}
+
+pub use heap_tuple::*;
+pub mod heap_tuple {
+    pub use ::pgx::heap_tuple::PgHeapTuple;
+}
+
+pub use iter::*;
+pub mod iter {
+    pub use ::pgx::iter::{SetOfIterator, TableIterator};
+}
+
+pub use memcxt::*;
+pub mod memcxt {
+    pub use ::pgx::memcxt::PgMemoryContexts;
+}
+
+pub use pgbox::*;
+pub mod pgbox {
+    pub use ::pgx::pgbox::{PgBox, WhoAllocated};
+}
+
+pub use pg_sys::*;
+pub mod pg_sys {
+    pub use ::pgx::pg_sys::elog::PgLogLevel;
+    pub use ::pgx::pg_sys::errcodes::PgSqlErrorCode;
+    pub use ::pgx::pg_sys::pg_try::PgTryBuilder;
+    pub use ::pgx::pg_sys::Datum;
+    pub use ::pgx::pg_sys::FuncCallContext;
+    pub use ::pgx::pg_sys::FunctionCallInfo;
+    pub use ::pgx::pg_sys::PgBuiltInOids;
+    pub use ::pgx::pg_sys::Pg_finfo_record;
+    pub use ::pgx::pg_sys::{ItemPointerData, Oid};
+
+    pub mod submodules {
+        pub mod elog {
+            pub use ::pgx::pg_sys::submodules::elog::PgLogLevel;
+        }
+
+        pub mod errcodes {
+            pub use ::pgx::pg_sys::submodules::errcodes::PgSqlErrorCode;
+        }
+
+        pub mod panic {
+            pub use ::pgx::pg_sys::submodules::panic::pgx_extern_c_guard;
+        }
+    }
+}
+
+pub use spi::Spi;
+pub mod spi {
+    pub use ::pgx::spi::{self, Error, Result, Spi};
+}
+
+pub use trigger_support::*;
+pub mod trigger_support {
+    pub use ::pgx::trigger_support::{
+        PgTrigger, PgTriggerError, PgTriggerLevel, PgTriggerOperation, PgTriggerWhen,
+    };
+}
+
+pub use pgx_macros::*;
+pub mod pgx_macros {
+    pub use ::pgx::pgx_macros::pg_extern;
+    pub use ::pgx::pgx_macros::pg_guard;
+    pub use ::pgx::pgx_macros::pg_trigger;
+}


### PR DESCRIPTION
Add a new module, `trusted-pgx` which exports the bare minimum things necessary for a standard plrust user function to not only compile, but to also pass safety checks, and to otherwise be usable to the developer.

### Notes

- We have a chicken/egg problem right now as the `trusted-pgx` crate isn't published, which is why its dependency is hardcoded to this repo + branch

- The user crate dependency on `pallocator` has been commented out.  Including it causes compilation errors

- Unclear if `trusted-pgx` exports everything a plrust user function will need.  I think it's probably pretty close

- All tests pass locally
