### PR TITLE
Diet of WORMs

### DIFF
--- a/plrust/src/plrust.rs
+++ b/plrust/src/plrust.rs
@@ -9,7 +9,7 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 
 use crate::{
     gucs, plrust_proc,
-    user_crate::{StateLoaded, UserCrate},
+    user_crate::{FnReady, UserCrate},
 };
 
 use pgx::{pg_sys::FunctionCallInfo, pg_sys::MyDatabaseId, prelude::*};
@@ -21,7 +21,7 @@ use crate::plrust_proc::get_target_triple;
 use eyre::WrapErr;
 
 thread_local! {
-    pub(crate) static LOADED_SYMBOLS: RefCell<HashMap<pg_sys::Oid, UserCrate<StateLoaded>>> = Default::default();
+    pub(crate) static LOADED_SYMBOLS: RefCell<HashMap<pg_sys::Oid, UserCrate<FnReady>>> = Default::default();
 }
 
 pub(crate) fn init() {

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -8,20 +8,25 @@ Consider opening the documentation like so:
 cargo doc --no-deps --document-private-items --open
 ```
 */
+#[path = "./state_validated.rs"]
+mod build;
 mod crate_variant;
-mod state_built;
-mod state_generated;
-mod state_loaded;
-mod state_provisioned;
-mod state_validated;
+#[path = "./state_generated.rs"]
+mod crating;
+#[path = "./state_built.rs"]
+mod loading;
+#[path = "./state_loaded.rs"]
+mod ready;
 mod target;
+#[path = "./state_provisioned.rs"]
+mod verify;
 
+pub(crate) use build::FnBuild;
 use crate_variant::CrateVariant;
-pub(crate) use state_built::FnLoad;
-pub(crate) use state_generated::FnCrating;
-pub(crate) use state_loaded::FnReady;
-pub(crate) use state_provisioned::FnVerify;
-pub(crate) use state_validated::FnBuild;
+pub(crate) use crating::FnCrating;
+pub(crate) use loading::FnLoad;
+pub(crate) use ready::FnReady;
+pub(crate) use verify::FnVerify;
 
 use crate::PlRustError;
 use pgx::{pg_sys, PgBuiltInOids, PgOid};
@@ -426,7 +431,7 @@ mod tests {
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
             let generated_lib_rs = generated.lib_rs()?;
-            let imports = crate::user_crate::state_generated::shared_imports();
+            let imports = crate::user_crate::crating::shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -87,11 +87,9 @@ impl UserCrate<FnCrating> {
     pub unsafe fn try_from_fn_oid(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid) -> eyre::Result<Self> {
         unsafe { FnCrating::try_from_fn_oid(db_oid, fn_oid).map(Self) }
     }
-    /// Two functions exist internally, a `safe_lib_rs` and `unsafe_lib_rs`.
-    /// At first, it only has access to `FnCrating::safe_lib_rs` due to the FSM.
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn lib_rs(&self) -> eyre::Result<syn::File> {
-        let (_, lib_rs) = self.0.safe_lib_rs()?;
+        let lib_rs = self.0.lib_rs()?;
         Ok(lib_rs)
     }
     #[tracing::instrument(level = "debug", skip_all)]

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -16,14 +16,12 @@ mod state_provisioned;
 mod state_validated;
 mod target;
 
-// TODO: These past-tense names are confusing to reason about
-// Consider rewriting them to present tense?
 use crate_variant::CrateVariant;
-pub(crate) use state_built::StateBuilt;
-pub(crate) use state_generated::StateGenerated;
-pub(crate) use state_loaded::StateLoaded;
-pub(crate) use state_provisioned::StateProvisioned;
-pub(crate) use state_validated::StateValidated;
+pub(crate) use state_built::FnLoad;
+pub(crate) use state_generated::FnCrating;
+pub(crate) use state_loaded::FnReady;
+pub(crate) use state_provisioned::FnVerify;
+pub(crate) use state_validated::FnBuild;
 
 use crate::PlRustError;
 use pgx::{pg_sys, PgBuiltInOids, PgOid};
@@ -40,12 +38,12 @@ Finite state machine with "typestate" generic
 
 This forces `UserCrate<P>` to follow the linear path:
 ```rust
-StateGenerated::try_from_$(inputs)_*
-  -> StateGenerated
-  -> StateProvisioned
-  -> StateValidated
-  -> StateBuilt
-  -> StateLoaded
+FnCrating::try_from_$(inputs)_*
+  -> FnCrating
+  -> FnVerify
+  -> FnBuild
+  -> FnLoad
+  -> FnReady
 ```
 Rust's ownership types allow guaranteeing one-way consumption.
 */
@@ -65,7 +63,7 @@ premature abstraction would be unwise.
 */
 pub(crate) trait CrateState {}
 
-impl UserCrate<StateGenerated> {
+impl UserCrate<FnCrating> {
     #[cfg(any(test, feature = "pg_test"))]
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn generated_for_tests(
@@ -76,7 +74,7 @@ impl UserCrate<StateGenerated> {
         user_code: syn::Block,
         variant: CrateVariant,
     ) -> Self {
-        Self(StateGenerated::for_tests(
+        Self(FnCrating::for_tests(
             pg_proc_xmin,
             db_oid,
             fn_oid,
@@ -87,10 +85,10 @@ impl UserCrate<StateGenerated> {
     }
     #[tracing::instrument(level = "debug", skip_all)]
     pub unsafe fn try_from_fn_oid(db_oid: pg_sys::Oid, fn_oid: pg_sys::Oid) -> eyre::Result<Self> {
-        unsafe { StateGenerated::try_from_fn_oid(db_oid, fn_oid).map(Self) }
+        unsafe { FnCrating::try_from_fn_oid(db_oid, fn_oid).map(Self) }
     }
     /// Two functions exist internally, a `safe_lib_rs` and `unsafe_lib_rs`.
-    /// At first, it only has access to `StateGenerated::safe_lib_rs` due to the FSM.
+    /// At first, it only has access to `FnCrating::safe_lib_rs` due to the FSM.
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn lib_rs(&self) -> eyre::Result<syn::File> {
         let (_, lib_rs) = self.0.safe_lib_rs()?;
@@ -102,12 +100,12 @@ impl UserCrate<StateGenerated> {
     }
     /// Provision into a given folder and return the crate directory.
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.0.db_oid(), fn_oid = %self.0.fn_oid()))]
-    pub fn provision(&self, parent_dir: &Path) -> eyre::Result<UserCrate<StateProvisioned>> {
+    pub fn provision(&self, parent_dir: &Path) -> eyre::Result<UserCrate<FnVerify>> {
         self.0.provision(parent_dir).map(UserCrate)
     }
 }
 
-impl UserCrate<StateProvisioned> {
+impl UserCrate<FnVerify> {
     #[tracing::instrument(
         level = "debug",
         skip_all,
@@ -121,7 +119,7 @@ impl UserCrate<StateProvisioned> {
         self,
         pg_config: PathBuf,
         target_dir: &Path,
-    ) -> eyre::Result<(UserCrate<StateValidated>, Output)> {
+    ) -> eyre::Result<(UserCrate<FnBuild>, Output)> {
         self.0
             .validate(pg_config, target_dir)
             .map(|(state, output)| (UserCrate(state), output))
@@ -132,7 +130,7 @@ impl UserCrate<StateProvisioned> {
     }
 }
 
-impl UserCrate<StateValidated> {
+impl UserCrate<FnBuild> {
     #[tracing::instrument(
         level = "debug",
         skip_all,
@@ -142,14 +140,14 @@ impl UserCrate<StateValidated> {
             crate_dir = %self.0.crate_dir().display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub fn build(self, target_dir: &Path) -> eyre::Result<(UserCrate<StateBuilt>, Output)> {
+    pub fn build(self, target_dir: &Path) -> eyre::Result<(UserCrate<FnLoad>, Output)> {
         self.0
             .build(target_dir)
             .map(|(state, output)| (UserCrate(state), output))
     }
 }
 
-impl UserCrate<StateBuilt> {
+impl UserCrate<FnLoad> {
     #[tracing::instrument(level = "debug")]
     pub(crate) fn built(
         pg_proc_xmin: pg_sys::TransactionId,
@@ -157,7 +155,7 @@ impl UserCrate<StateBuilt> {
         fn_oid: pg_sys::Oid,
         shared_object: PathBuf,
     ) -> Self {
-        UserCrate(StateBuilt::new(
+        UserCrate(FnLoad::new(
             pg_proc_xmin,
             db_oid,
             fn_oid,
@@ -169,12 +167,12 @@ impl UserCrate<StateBuilt> {
         self.0.shared_object()
     }
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.0.db_oid(), fn_oid = %self.0.fn_oid()))]
-    pub unsafe fn load(self) -> eyre::Result<UserCrate<StateLoaded>> {
+    pub unsafe fn load(self) -> eyre::Result<UserCrate<FnReady>> {
         unsafe { self.0.load().map(UserCrate) }
     }
 }
 
-impl UserCrate<StateLoaded> {
+impl UserCrate<FnReady> {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid(), fn_oid = %self.fn_oid()))]
     pub unsafe fn evaluate(&self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         unsafe { self.0.evaluate(fcinfo) }

--- a/plrust/src/user_crate/state_built.rs
+++ b/plrust/src/user_crate/state_built.rs
@@ -1,19 +1,19 @@
-use crate::user_crate::{CrateState, StateLoaded};
+use crate::user_crate::{CrateState, FnReady};
 use pgx::pg_sys;
 use std::path::{Path, PathBuf};
 
 #[must_use]
-pub(crate) struct StateBuilt {
+pub(crate) struct FnLoad {
     pg_proc_xmin: pg_sys::TransactionId,
     db_oid: pg_sys::Oid,
     fn_oid: pg_sys::Oid,
     shared_object: PathBuf,
 }
 
-impl CrateState for StateBuilt {}
+impl CrateState for FnLoad {}
 
 /// Available and ready-to-reload PL/Rust function
-impl StateBuilt {
+impl FnLoad {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn new(
         pg_proc_xmin: pg_sys::TransactionId,
@@ -42,11 +42,11 @@ impl StateBuilt {
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid, shared_object = %self.shared_object.display()))]
-    pub(crate) unsafe fn load(self) -> eyre::Result<StateLoaded> {
+    pub(crate) unsafe fn load(self) -> eyre::Result<FnReady> {
         unsafe {
             // SAFETY:  Caller is responsible for ensuring self.shared_object points to the proper
             // shared library to be loaded
-            StateLoaded::load(
+            FnReady::load(
                 self.pg_proc_xmin,
                 self.db_oid,
                 self.fn_oid,

--- a/plrust/src/user_crate/state_generated.rs
+++ b/plrust/src/user_crate/state_generated.rs
@@ -323,7 +323,14 @@ fn unsafe_mod(mut called_fn: syn::ItemFn, variant: &CrateVariant) -> eyre::Resul
 
 fn safe_mod(bare_fn: syn::ItemFn) -> eyre::Result<syn::ItemMod> {
     let imports = shared_imports();
-
+    // Hello from the futurepast!
+    // The only situation in which you should be removing this
+    // `#![forbid(unsafe_code)]` is if you are moving the forbid
+    // command somewhere else  or reconfiguring PL/Rust to also
+    // allow it to be run in a fully "Untrusted PL/Rust" mode.
+    // This enables the code checking not only for `unsafe {}`
+    // but also "unsafe attributes" which are considered unsafe
+    // but don't have the `unsafe` token.
     syn::parse2(quote! {
         mod forbidden {
             #![forbid(unsafe_code)]

--- a/plrust/src/user_crate/state_generated.rs
+++ b/plrust/src/user_crate/state_generated.rs
@@ -98,44 +98,30 @@ impl FnCrating {
         _crate_name
     }
 
-    /// Generates the initial, "pure Rust" wrapper for the PL/Rust function,
-    /// allowing it to be used for typechecking.
+    /// Generates the lib.rs to write
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
-    pub(crate) fn safe_lib_rs(&self) -> eyre::Result<(syn::ItemFn, syn::File)> {
-        // Hello from the futurepast!
-        // The only situation in which you should be removing this `#![forbid(unsafe_code)]`
-        // from the skeleton code is if you are moving the forbid command somewhere else
-        // or reconfiguring PL/Rust to also allow it to be run in a fully "untrusted" mode.
-        // This is what does all of the code checking not only for `unsafe {}` but also
-        // "unsafe attributes" which are considered unsafe but don't have the `unsafe` token.
-        let mut skeleton: syn::File = syn::parse_quote!(
-            #![forbid(unsafe_code)]
-            use pgx::prelude::*;
-        );
-
+    pub(crate) fn lib_rs(&self) -> eyre::Result<syn::File> {
         let crate_name = self.crate_name();
         let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
-
         tracing::trace!(symbol_name = %crate_name, "Generating `lib.rs` for validation step");
 
         let user_code = &self.user_code;
-        let user_fn = match &self.variant {
+        let user_fn: syn::ItemFn = match &self.variant {
             CrateVariant::Function {
                 ref arguments,
                 ref return_type,
                 ..
             } => {
-                let user_fn: syn::ItemFn = syn::parse2(quote! {
+                syn::parse2(quote! {
                     fn #symbol_ident(
                         #( #arguments ),*
                     ) -> #return_type
                     #user_code
                 })
-                .wrap_err("Parsing generated user function")?;
-                user_fn
+                .wrap_err("Parsing generated user function")?
             }
             CrateVariant::Trigger => {
-                let user_fn: syn::ItemFn = syn::parse2(quote! {
+                syn::parse2(quote! {
                     fn #symbol_ident(
                         trigger: &::pgx::PgTrigger,
                     ) -> ::core::result::Result<
@@ -143,13 +129,13 @@ impl FnCrating {
                         Box<dyn std::error::Error>,
                     > #user_code
                 })
-                .wrap_err("Parsing generated user trigger")?;
-                user_fn
+                .wrap_err("Parsing generated user trigger")?
             }
         };
+        let opened = unsafe_mod(user_fn.clone(), &self.variant)?;
+        let forbidden = safe_mod(user_fn)?;
 
-        skeleton.items.push(user_fn.clone().into());
-        Ok((user_fn, skeleton))
+        compose_lib_from_mods([opened, forbidden])
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %self.db_oid, fn_oid = %self.fn_oid))]
@@ -257,7 +243,7 @@ impl FnCrating {
             "Could not create crate directory in configured `plrust.work_dir` location",
         )?;
 
-        let (user_fn, lib_rs) = self.safe_lib_rs()?;
+        let lib_rs = self.lib_rs()?;
         let lib_rs_path = src_dir.join("lib.rs");
         std::fs::write(&lib_rs_path, &prettyplease::unparse(&lib_rs))
             .wrap_err("Writing generated `lib.rs`")?;
@@ -276,8 +262,6 @@ impl FnCrating {
             self.fn_oid,
             crate_name,
             crate_dir,
-            user_fn,
-            self.variant.clone(),
         ))
     }
 
@@ -288,6 +272,67 @@ impl FnCrating {
     pub(crate) fn db_oid(&self) -> pg_sys::Oid {
         self.db_oid
     }
+}
+
+/// Throw all the libs into this, we will write this once.
+fn compose_lib_from_mods<const N: usize>(modules: [syn::ItemMod; N]) -> eyre::Result<syn::File> {
+    let mut skeleton: syn::File = syn::parse2(quote! {
+        #![deny(unsafe_op_in_unsafe_fn)]
+    })
+    .wrap_err("Generating lib skeleton")?;
+
+    for module in modules {
+        skeleton.items.push(module.into());
+    }
+    Ok(skeleton)
+}
+
+/// Used by both the unsafe and safe module.
+fn shared_imports() -> syn::ItemUse {
+    syn::parse_quote!(
+        use pgx::prelude::*;
+    )
+}
+
+fn unsafe_mod(mut called_fn: syn::ItemFn, variant: &CrateVariant) -> eyre::Result<syn::ItemMod> {
+    let imports = shared_imports();
+
+    match variant {
+        CrateVariant::Function { .. } => {
+            called_fn.attrs.push(syn::parse_quote! {
+                #[pg_extern]
+            });
+        }
+        CrateVariant::Trigger => {
+            called_fn.attrs.push(syn::parse_quote! {
+                #[pg_trigger]
+            });
+        }
+    };
+
+    // Use pub mod so that symbols inside are found, opened, and called
+    syn::parse2(quote! {
+        pub mod opened {
+            #imports
+
+            #called_fn
+        }
+    })
+    .wrap_err("Could not create opened module")
+}
+
+fn safe_mod(bare_fn: syn::ItemFn) -> eyre::Result<syn::ItemMod> {
+    let imports = shared_imports();
+
+    syn::parse2(quote! {
+        mod forbidden {
+            #![forbid(unsafe_code)]
+            #imports
+
+            #bare_fn
+        }
+    })
+    .wrap_err("Could not create forbidden module")
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -317,14 +362,8 @@ mod tests {
                 { Some(arg0.to_string()) }
             })?;
 
-            let generated = FnCrating::for_tests(
-                pg_proc_xmin,
-                db_oid,
-                fn_oid,
-                user_deps,
-                user_code,
-                variant,
-            );
+            let generated =
+                FnCrating::for_tests(pg_proc_xmin, db_oid, fn_oid, user_deps, user_code, variant);
 
             let crate_name = crate::plrust::crate_name(db_oid, fn_oid);
             #[cfg(any(
@@ -341,12 +380,27 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
-            let fixture_lib_rs = parse_quote! {
-                #![forbid(unsafe_code)]
-                use pgx::prelude::*;
+            let generated_lib_rs = generated.lib_rs()?;
+            let imports = shared_imports();
+            let bare_fn: syn::ItemFn = syn::parse2(quote! {
                 fn #symbol_ident(arg0: &str) -> Option<String> {
                     Some(arg0.to_string())
+                }
+            })?;
+            let fixture_lib_rs = parse_quote! {
+                #![deny(unsafe_op_in_unsafe_fn)]
+                pub mod opened {
+                    #imports
+
+                    #[pg_extern]
+                    #bare_fn
+                }
+
+                mod forbidden {
+                    #![forbid(unsafe_code)]
+                    #imports
+
+                    #bare_fn
                 }
             };
             assert_eq!(
@@ -381,14 +435,8 @@ mod tests {
                 { val.map(|v| v as i64) }
             })?;
 
-            let generated = FnCrating::for_tests(
-                pg_proc_xmin,
-                db_oid,
-                fn_oid,
-                user_deps,
-                user_code,
-                variant,
-            );
+            let generated =
+                FnCrating::for_tests(pg_proc_xmin, db_oid, fn_oid, user_deps, user_code, variant);
 
             let crate_name = crate::plrust::crate_name(db_oid, fn_oid);
             #[cfg(any(
@@ -405,7 +453,7 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
+            let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
                 #![forbid(unsafe_code)]
                 use pgx::prelude::*;
@@ -445,14 +493,8 @@ mod tests {
                 { Some(std::iter::repeat(val).take(5)) }
             })?;
 
-            let generated = FnCrating::for_tests(
-                pg_proc_xmin,
-                db_oid,
-                fn_oid,
-                user_deps,
-                user_code,
-                variant,
-            );
+            let generated =
+                FnCrating::for_tests(pg_proc_xmin, db_oid, fn_oid, user_deps, user_code, variant);
 
             let crate_name = crate::plrust::crate_name(db_oid, fn_oid);
             #[cfg(any(
@@ -469,7 +511,7 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
+            let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
                 #![forbid(unsafe_code)]
                 use pgx::prelude::*;
@@ -500,14 +542,8 @@ mod tests {
                 { Ok(trigger.current().unwrap().into_owned()) }
             })?;
 
-            let generated = FnCrating::for_tests(
-                pg_proc_xmin,
-                db_oid,
-                fn_oid,
-                user_deps,
-                user_code,
-                variant,
-            );
+            let generated =
+                FnCrating::for_tests(pg_proc_xmin, db_oid, fn_oid, user_deps, user_code, variant);
 
             let crate_name = crate::plrust::crate_name(db_oid, fn_oid);
             #[cfg(any(
@@ -524,7 +560,7 @@ mod tests {
             };
             let symbol_ident = proc_macro2::Ident::new(&crate_name, proc_macro2::Span::call_site());
 
-            let (_, generated_lib_rs) = generated.safe_lib_rs()?;
+            let generated_lib_rs = generated.lib_rs()?;
             let fixture_lib_rs = parse_quote! {
                 #![forbid(unsafe_code)]
                 use pgx::prelude::*;

--- a/plrust/src/user_crate/state_loaded.rs
+++ b/plrust/src/user_crate/state_loaded.rs
@@ -3,11 +3,11 @@ use libloading::os::unix::{Library, Symbol};
 use pgx::pg_sys;
 use std::path::{Path, PathBuf};
 
-impl CrateState for StateLoaded {}
+impl CrateState for FnReady {}
 
 /// Available and ready-to-reload PL/Rust function
 #[must_use]
-pub(crate) struct StateLoaded {
+pub(crate) struct FnReady {
     pg_proc_xmin: pg_sys::TransactionId,
     db_oid: pg_sys::Oid,
     fn_oid: pg_sys::Oid,
@@ -18,7 +18,7 @@ pub(crate) struct StateLoaded {
     symbol: Symbol<unsafe extern "C" fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum>,
 }
 
-impl StateLoaded {
+impl FnReady {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %db_oid, fn_oid = %fn_oid, shared_object = %shared_object.display()))]
     pub(crate) unsafe fn load(
         pg_proc_xmin: pg_sys::TransactionId,

--- a/plrust/src/user_crate/state_validated.rs
+++ b/plrust/src/user_crate/state_validated.rs
@@ -103,10 +103,8 @@ impl FnBuild {
                 output,
             ))
         } else {
-            let stdout =
-                String::from_utf8(output.stdout).wrap_err("`cargo`'s stdout was not  UTF-8")?;
-            let stderr =
-                String::from_utf8(output.stderr).wrap_err("`cargo`'s stderr was not  UTF-8")?;
+            let stdout = String::from_utf8(output.stdout).wrap_err("cargo stdout was not UTF-8")?;
+            let stderr = String::from_utf8(output.stderr).wrap_err("cargo stderr was not UTF-8")?;
 
             Err(eyre!(PlRustError::CargoBuildFail)
                 .section(stdout.header("`cargo build` stdout:"))

--- a/plrust/src/user_crate/state_validated.rs
+++ b/plrust/src/user_crate/state_validated.rs
@@ -1,5 +1,5 @@
 use crate::{
-    user_crate::{target, CrateState, StateBuilt},
+    user_crate::{target, CrateState, FnLoad},
     PlRustError,
 };
 use color_eyre::{Section, SectionExt};
@@ -12,7 +12,7 @@ use std::{
 
 /// Validated and ready to build
 #[must_use]
-pub(crate) struct StateValidated {
+pub(crate) struct FnBuild {
     pg_proc_xmin: pg_sys::TransactionId,
     db_oid: pg_sys::Oid,
     fn_oid: pg_sys::Oid,
@@ -21,9 +21,9 @@ pub(crate) struct StateValidated {
     pg_config: PathBuf,
 }
 
-impl CrateState for StateValidated {}
+impl CrateState for FnBuild {}
 
-impl StateValidated {
+impl FnBuild {
     #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %db_oid, fn_oid = %fn_oid, crate_name = %crate_name, crate_dir = %crate_dir.display()))]
     pub(crate) fn new(
         pg_proc_xmin: pg_sys::TransactionId,
@@ -52,7 +52,7 @@ impl StateValidated {
             crate_dir = %self.crate_dir.display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub(crate) fn build(self, target_dir: &Path) -> eyre::Result<(StateBuilt, Output)> {
+    pub(crate) fn build(self, target_dir: &Path) -> eyre::Result<(FnLoad, Output)> {
         let mut command = Command::new("cargo");
         let target = target::tuple()?;
         let target_str = &target;
@@ -94,7 +94,7 @@ impl StateValidated {
                 .join(&built_shared_object_name);
 
             Ok((
-                StateBuilt::new(
+                FnLoad::new(
                     self.pg_proc_xmin,
                     self.db_oid,
                     self.fn_oid,


### PR DESCRIPTION
This allows PL/Rust to feed on a filesystem that has been configured to only allow "write-once read-many" or WORM. It fixes https://github.com/tcdi/plrust/issues/139 as one might imagine.

The unusual path remapping hack is only for this PR, I intend to fix it in the next. For various reasons I don't want to chance losing the git history for these files (yet).