### PR TITLE
Change to use the `pgx:develop` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,17 +60,6 @@ checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
 dependencies = [
  "cfg-if",
  "rustc_version 0.3.3",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -185,6 +180,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
+dependencies = [
+ "clap",
+ "doc-comment",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +255,12 @@ name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -331,6 +376,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -510,6 +561,12 @@ dependencies = [
  "spin",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -697,6 +754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +796,12 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -767,6 +839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathsearch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da983bc5e582ab17179c190b4b66c7d76c5943a69c6d34df2a2b6bf8a2977b05"
+dependencies = [
+ "anyhow",
+ "libc",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,21 +883,18 @@ dependencies = [
 [[package]]
 name = "pgx"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708693428ee16491645c1c2795f6777a78b9b1d08ab2e481a82b7977c9814b56"
+source = "git+https://github.com/tcdi/pgx?branch=develop#d7dd218c2709615b75f7fb6e70a2a4f6c59e1fd6"
 dependencies = [
  "atomic-traits",
  "bitflags",
  "bitvec",
  "cstr_core",
- "eyre",
  "heapless",
  "libc",
  "once_cell",
  "pgx-macros",
  "pgx-pg-sys",
- "pgx-utils",
- "quote",
+ "pgx-sql-entity-graph",
  "seahash",
  "seq-macro",
  "serde",
@@ -831,25 +910,23 @@ dependencies = [
 [[package]]
 name = "pgx-macros"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0050ca15df7dbfe718f9006d2b9a38d2a00a40934d8154450cdde6323b58b690"
+source = "git+https://github.com/tcdi/pgx?branch=develop#d7dd218c2709615b75f7fb6e70a2a4f6c59e1fd6"
 dependencies = [
- "pgx-utils",
+ "pgx-sql-entity-graph",
  "proc-macro2",
  "quote",
  "syn",
- "unescape",
 ]
 
 [[package]]
 name = "pgx-pg-config"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000bba0f67f2aa20e971a6127a8971bd85a6b724d3e95d9066f64816de3b4e67"
+source = "git+https://github.com/tcdi/pgx?branch=develop#d7dd218c2709615b75f7fb6e70a2a4f6c59e1fd6"
 dependencies = [
  "dirs",
  "eyre",
  "owo-colors",
+ "pathsearch",
  "serde",
  "serde_derive",
  "serde_json",
@@ -860,54 +937,27 @@ dependencies = [
 [[package]]
 name = "pgx-pg-sys"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd3fd6e1bcbfed67da7ac2dc71986a9f1396aeaec3d449d0697eb54909b34a"
+source = "git+https://github.com/tcdi/pgx?branch=develop#d7dd218c2709615b75f7fb6e70a2a4f6c59e1fd6"
 dependencies = [
  "bindgen",
  "eyre",
  "libc",
  "memoffset 0.6.5",
- "once_cell",
  "pgx-macros",
  "pgx-pg-config",
- "pgx-utils",
+ "pgx-sql-entity-graph",
  "proc-macro2",
  "quote",
- "rayon",
  "shlex",
  "sptr",
  "syn",
 ]
 
 [[package]]
-name = "pgx-tests"
+name = "pgx-sql-entity-graph"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44db59e5a5473f9192cff05a284677b8b491bffcf85dcc7b892339f084ad2f2b"
+source = "git+https://github.com/tcdi/pgx?branch=develop#d7dd218c2709615b75f7fb6e70a2a4f6c59e1fd6"
 dependencies = [
- "eyre",
- "libc",
- "once_cell",
- "owo-colors",
- "pgx",
- "pgx-macros",
- "pgx-pg-config",
- "pgx-utils",
- "postgres",
- "regex",
- "serde",
- "serde_json",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "pgx-utils"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cdc413efcd90a1e94c7f09dea24ec1ecfa1275350cbe378a8776eb7b5448f9"
-dependencies = [
- "atty",
  "convert_case",
  "cstr_core",
  "eyre",
@@ -916,14 +966,33 @@ dependencies = [
  "quote",
  "regex",
  "seq-macro",
- "serde",
- "serde_derive",
- "serde_json",
  "syn",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
  "unescape",
+]
+
+[[package]]
+name = "pgx-tests"
+version = "0.6.1"
+source = "git+https://github.com/tcdi/pgx?branch=develop#d7dd218c2709615b75f7fb6e70a2a4f6c59e1fd6"
+dependencies = [
+ "clap-cargo",
+ "eyre",
+ "libc",
+ "once_cell",
+ "owo-colors",
+ "pgx",
+ "pgx-macros",
+ "pgx-pg-config",
+ "postgres",
+ "regex",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -1039,6 +1108,30 @@ checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1432,6 +1525,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17351d0e9eb8841897b14e9669378f3c69fb57779cc04f8ca9a9d512edfb2563"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -31,8 +31,8 @@ once_cell = "1.7.2" # polyfills a nightly feature
 semver = "1.0.14"
 
 # pgx core details
-pgx = { version = "=0.6.1" }
-pgx-pg-config = { version = "=0.6.1" }
+pgx = { git = "https://github.com/tcdi/pgx", branch = "develop" }
+pgx-pg-config = { git = "https://github.com/tcdi/pgx", branch = "develop" }
 
 # language handler support
 libloading = "0.7.2"
@@ -55,7 +55,7 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-pgx-tests = { version = "=0.6.1" }
+pgx-tests = { git = "https://github.com/tcdi/pgx", branch = "develop" }
 tempdir = "0.3.7"
 once_cell = "1.7.2"
 toml = "0.5.8"

--- a/plrust/src/hooks.rs
+++ b/plrust/src/hooks.rs
@@ -1,7 +1,8 @@
 use std::ffi::CStr;
 
 use pgx::{
-    pg_guard, pg_sys, IntoDatum, PgBox, PgBuiltInOids, PgList, PgLogLevel, PgSqlErrorCode, Spi,
+    ereport, pg_guard, pg_sys, spi, IntoDatum, PgBox, PgBuiltInOids, PgList, PgLogLevel,
+    PgSqlErrorCode, Spi,
 };
 
 use crate::pgproc::PgProc;
@@ -104,10 +105,18 @@ fn plrust_process_utility_hook_internal(
         match drop_stmt.removeType {
             pg_sys::ObjectType_OBJECT_FUNCTION => handle_drop_function(&drop_stmt),
             pg_sys::ObjectType_OBJECT_SCHEMA => handle_drop_schema(&drop_stmt),
-            _ => {
-                // we don't do anything for the other objects
-            }
+
+            // we don't do anything for the other objects
+            _ => Ok(()),
         }
+        .unwrap_or_else(|e| {
+            ereport!(
+                PgLogLevel::ERROR,
+                PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                "failed to handle drop statement",
+                &format!("{}", e)
+            )
+        });
 
         // call the previous hook last.  We want to call it after our work because we need the catalog
         // entries in place to find/ensure that we only affect plrust functions.
@@ -232,7 +241,7 @@ fn handle_alter_function(alter_stmt: &PgBox<pg_sys::AlterFunctionStmt>) {
 }
 
 /// drop all the `LANGUAGE plrust` functions from the set of all functions being dropped by the [`DropStmt`]
-fn handle_drop_function(drop_stmt: &PgBox<pg_sys::DropStmt>) {
+fn handle_drop_function(drop_stmt: &PgBox<pg_sys::DropStmt>) -> spi::Result<()> {
     let plrust_lang_oid = plrust_lang_oid();
 
     for pg_proc_oid in objects(drop_stmt, pg_sys::ProcedureRelationId).filter_map(|oa| {
@@ -240,17 +249,19 @@ fn handle_drop_function(drop_stmt: &PgBox<pg_sys::DropStmt>) {
         // if it's a pl/rust function we can drop it
         (lang_oid == plrust_lang_oid).then(|| oa.objectId)
     }) {
-        plrust_proc::drop_function(pg_proc_oid);
+        plrust_proc::drop_function(pg_proc_oid)?;
     }
+    Ok(())
 }
 
 /// drop all `LANGUAGE plrust` functions in any of the schemas being dropped by the [`DropStmt`]
-fn handle_drop_schema(drop_stmt: &PgBox<pg_sys::DropStmt>) {
+fn handle_drop_schema(drop_stmt: &PgBox<pg_sys::DropStmt>) -> spi::Result<()> {
     for object in objects(drop_stmt, pg_sys::NamespaceRelationId) {
-        for pg_proc_oid in all_in_namespace(object.objectId) {
-            plrust_proc::drop_function(pg_proc_oid)
+        for pg_proc_oid in all_in_namespace(object.objectId)? {
+            plrust_proc::drop_function(pg_proc_oid)?;
         }
     }
+    Ok(())
 }
 
 /// Returns an iterator over the `objects` in the `[DropStmt]`, filtered by only those of the
@@ -295,7 +306,7 @@ fn objects(
 
 /// Returns an Iterator of `LANGUAGE plrust` function oids (`pg_catalog.pg_proc.oid`) in a specific namespace
 #[tracing::instrument(level = "debug")]
-pub(crate) fn all_in_namespace(pg_namespace_oid: pg_sys::Oid) -> Vec<pg_sys::Oid> {
+pub(crate) fn all_in_namespace(pg_namespace_oid: pg_sys::Oid) -> spi::Result<Vec<pg_sys::Oid>> {
     Spi::connect(|client| {
         let results = client.select(
             r#"
@@ -309,21 +320,15 @@ pub(crate) fn all_in_namespace(pg_namespace_oid: pg_sys::Oid) -> Vec<pg_sys::Oid
                 PgBuiltInOids::OIDOID.oid(),
                 pg_namespace_oid.into_datum(),
             )]),
-        );
+        )?;
 
         let proc_oids = results
             .into_iter()
-            .map(|row| {
-                row.by_ordinal(1)
-                    .ok()
-                    .unwrap()
-                    .value::<pg_sys::Oid>()
-                    .unwrap()
-            })
-            .collect::<Vec<_>>();
+            .map(|row| Ok(row.get::<pg_sys::Oid>(1)?.unwrap()))
+            .collect::<spi::Result<Vec<_>>>()?;
 
-        Ok(Some(proc_oids))
-    }).unwrap()
+        Ok(proc_oids)
+    })
 }
 
 /// Return the specified function's `prolang` value from `pg_catalog.pg_proc`

--- a/plrust/src/hooks.rs
+++ b/plrust/src/hooks.rs
@@ -322,12 +322,10 @@ pub(crate) fn all_in_namespace(pg_namespace_oid: pg_sys::Oid) -> spi::Result<Vec
             )]),
         )?;
 
-        let proc_oids = results
+        results
             .into_iter()
             .map(|row| Ok(row.get::<pg_sys::Oid>(1)?.unwrap()))
-            .collect::<spi::Result<Vec<_>>>()?;
-
-        Ok(proc_oids)
+            .collect::<spi::Result<Vec<_>>>()
     })
 }
 

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -163,8 +163,8 @@ impl FnCrating {
                     crate-type = ["cdylib"]
 
                     [dependencies]
-                    pgx =  { version = "=0.6.1", features = ["plrust"] }
-                    pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
+                    pgx =  { git = "https://github.com/tcdi/pgx", branch = "develop" }
+                    // pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
 
                     /* User deps added here */
 

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -469,8 +469,8 @@ mod tests {
                 crate-type = ["cdylib"]
 
                 [dependencies]
-                pgx = { version = "=0.6.1", features = ["plrust"] }
-                pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
+                pgx = { git = "https://github.com/tcdi/pgx", branch = "develop" }
+                // pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
                 /* User deps added here */
 
                 [profile.release]


### PR DESCRIPTION
For now, lets have plrust use pgx' `develop` branch, so we can move forward with the "trusted-pgx" crate.

This PR makes that change and updates the code (mostly around Spi) so that it compiles.

Also note that the user function dependency on `pallocator` has been commented out -- I believe that needs some TLC against pgx:develop as well.