### PR TITLE
plrust functions now return `Result<Option<T>>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An example PL/Rust function:
 ```sql
 // return the character length of a text string
 CREATE FUNCTION strlen(name TEXT) RETURNS int LANGUAGE plrust AS $$
-    Some(name?.len() as i32)
+    Ok(Some(name?.len() as i32))
 $$;
 
 # select strlen('Hello, PL/Rust');

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -8,6 +8,7 @@ RETURNS {ret}
 -- function attributes can go here
 AS $$
     // PL/Rust function body goes here
+    // All PL/Rust functions return Result<Option<{ret}>>
 $$ LANGUAGE plrust;
 ```
 

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -271,7 +271,7 @@ mod tests {
                 IMMUTABLE STRICT
                 LANGUAGE PLRUST AS
             $$
-                Ok(::pgx::iter::SetOfIterator::new(names.into_iter().map(|maybe| maybe.map(|name| name.to_string() + " was booped!"))))
+                Ok(Some(::pgx::iter::SetOfIterator::new(names.into_iter().map(|maybe| maybe.map(|name| name.to_string() + " was booped!")))))
             $$;
         "#;
         Spi::run(definition)?;

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -271,7 +271,7 @@ mod tests {
                 IMMUTABLE STRICT
                 LANGUAGE PLRUST AS
             $$
-                Some(::pgx::iter::SetOfIterator::new(names.into_iter().map(|maybe| maybe.map(|name| name.to_string() + " was booped!"))))
+                Ok(::pgx::iter::SetOfIterator::new(names.into_iter().map(|maybe| maybe.map(|name| name.to_string() + " was booped!"))))
             $$;
         "#;
         Spi::run(definition)?;

--- a/plrust/src/user_crate/crate_variant.rs
+++ b/plrust/src/user_crate/crate_variant.rs
@@ -69,7 +69,7 @@ impl CrateVariant {
         let return_type: syn::Type = {
             let bare = oid_to_syn_type(&return_oid, true)?;
             match return_set {
-                true => syn::parse2(quote! { Option<::pgx::iter::SetOfIterator<Option<#bare>>> })
+                true => syn::parse2(quote! { std::result::Result<Option<::pgx::iter::SetOfIterator<Option<#bare>>>, Box<dyn std::error::Error>> })
                     .wrap_err("Wrapping return type")?,
                 false => syn::parse2(
                     quote! { std::result::Result<Option<#bare>, Box<dyn std::error::Error>> },

--- a/plrust/src/user_crate/crate_variant.rs
+++ b/plrust/src/user_crate/crate_variant.rs
@@ -69,10 +69,10 @@ impl CrateVariant {
         let return_type: syn::Type = {
             let bare = oid_to_syn_type(&return_oid, true)?;
             match return_set {
-                true => syn::parse2(quote! { std::result::Result<Option<::pgx::iter::SetOfIterator<Option<#bare>>>, Box<dyn std::error::Error>> })
+                true => syn::parse2(quote! { ::std::result::Result<Option<::pgx::iter::SetOfIterator<Option<#bare>>>, Box<dyn ::std::error::Error>> })
                     .wrap_err("Wrapping return type")?,
                 false => syn::parse2(
-                    quote! { std::result::Result<Option<#bare>, Box<dyn std::error::Error>> },
+                    quote! { ::std::result::Result<Option<#bare>, Box<dyn ::std::error::Error>> },
                 )
                 .wrap_err("Wrapping return type")?,
             }

--- a/plrust/src/user_crate/crate_variant.rs
+++ b/plrust/src/user_crate/crate_variant.rs
@@ -71,7 +71,10 @@ impl CrateVariant {
             match return_set {
                 true => syn::parse2(quote! { Option<::pgx::iter::SetOfIterator<Option<#bare>>> })
                     .wrap_err("Wrapping return type")?,
-                false => syn::parse2(quote! { Option<#bare> }).wrap_err("Wrapping return type")?,
+                false => syn::parse2(
+                    quote! { std::result::Result<Option<#bare>, Box<dyn std::error::Error>> },
+                )
+                .wrap_err("Wrapping return type")?,
             }
         };
 

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -516,7 +516,7 @@ mod tests {
             };
             let user_deps = toml::value::Table::default();
             let user_code = syn::parse2(quote! {
-                { Some(std::iter::repeat(val).take(5)) }
+                { Ok(Some(std::iter::repeat(val).take(5))) }
             })?;
 
             let generated =
@@ -540,8 +540,8 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(val: &str) -> Option<::pgx::iter::SetOfIterator<Option<String>>> {
-                    Some(std::iter::repeat(val).take(5))
+                fn #symbol_ident(val: &str) -> std::result::Result<Option<::pgx::iter::SetOfIterator<Option<String>>>, Box<dyn std::error::Error>> {
+                    Ok(Some(std::iter::repeat(val).take(5)))
                 }
             })?;
             let fixture_lib_rs = parse_quote! {

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -394,7 +394,7 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(arg0: &str) -> std::result::Result<Option<String>, Box<dyn std::error::Error>> {
+                fn #symbol_ident(arg0: &str) -> ::std::result::Result<Option<String>, Box<dyn ::std::error::Error>> {
                     Some(arg0.to_string())
                 }
             })?;
@@ -467,7 +467,7 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(val: Option<i32>) -> std::result::Result<Option<i64>, Box<dyn std::error::Error>> {
+                fn #symbol_ident(val: Option<i32>) -> ::std::result::Result<Option<i64>, Box<dyn ::std::error::Error>> {
                     val.map(|v| v as i64)
                 }
             })?;
@@ -540,7 +540,7 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(val: &str) -> std::result::Result<Option<::pgx::iter::SetOfIterator<Option<String>>>, Box<dyn std::error::Error>> {
+                fn #symbol_ident(val: &str) -> ::std::result::Result<Option<::pgx::iter::SetOfIterator<Option<String>>>, Box<dyn ::std::error::Error>> {
                     Ok(Some(std::iter::repeat(val).take(5)))
                 }
             })?;

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -394,7 +394,7 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(arg0: &str) -> Option<String> {
+                fn #symbol_ident(arg0: &str) -> std::result::Result<Option<String>, Box<dyn std::error::Error>> {
                     Some(arg0.to_string())
                 }
             })?;
@@ -467,7 +467,7 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(val: Option<i32>) -> Option<i64> {
+                fn #symbol_ident(val: Option<i32>) -> std::result::Result<Option<i64>, Box<dyn std::error::Error>> {
                     val.map(|v| v as i64)
                 }
             })?;

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -402,7 +402,7 @@ mod tests {
             };
             let user_deps = toml::value::Table::default();
             let user_code = syn::parse2(quote! {
-                { Some(arg0.to_string()) }
+                { Ok(Some(arg0.to_string())) }
             })?;
 
             let generated = UserCrate::generated_for_tests(
@@ -431,8 +431,8 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = crate::user_crate::crating::shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(arg0: &str) -> Option<String> {
-                    Some(arg0.to_string())
+                fn #symbol_ident(arg0: &str) -> std::result::Result<Option<String>, Box<dyn std::error::Error>> {
+                    Ok(Some(arg0.to_string()))
                 }
             })?;
             let fixture_lib_rs = parse_quote! {

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -431,7 +431,7 @@ mod tests {
             let generated_lib_rs = generated.lib_rs()?;
             let imports = crate::user_crate::crating::shared_imports();
             let bare_fn: syn::ItemFn = syn::parse2(quote! {
-                fn #symbol_ident(arg0: &str) -> std::result::Result<Option<String>, Box<dyn std::error::Error>> {
+                fn #symbol_ident(arg0: &str) -> ::std::result::Result<Option<String>, Box<dyn ::std::error::Error>> {
                     Ok(Some(arg0.to_string()))
                 }
             })?;

--- a/trusted-pgx/src/lib.rs
+++ b/trusted-pgx/src/lib.rs
@@ -55,6 +55,10 @@ pub mod pg_sys {
     pub use ::pgx::pg_sys::Pg_finfo_record;
     pub use ::pgx::pg_sys::{ItemPointerData, Oid};
 
+    pub mod panic {
+        pub use super::submodules::panic::ErrorReportable;
+    }
+
     pub mod submodules {
         pub mod elog {
             pub use ::pgx::pg_sys::submodules::elog::PgLogLevel;
@@ -66,6 +70,7 @@ pub mod pg_sys {
 
         pub mod panic {
             pub use ::pgx::pg_sys::submodules::panic::pgx_extern_c_guard;
+            pub use ::pgx::pg_sys::submodules::panic::ErrorReportable;
         }
     }
 }

--- a/trusted-pgx/src/lib.rs
+++ b/trusted-pgx/src/lib.rs
@@ -43,6 +43,7 @@ pub mod pgbox {
     pub use ::pgx::pgbox::{PgBox, WhoAllocated};
 }
 
+pub use pg_sys::panic::ErrorReportable;
 pub use pg_sys::*;
 pub mod pg_sys {
     pub use ::pgx::pg_sys::elog::PgLogLevel;


### PR DESCRIPTION
This does the work, which was mostly updating our tests, to change the wrapper function plrust writes for user functions to return `Result<Option<T>, Box<dyn Error>>` instead of a plain `Option<T>`.

This, I truly believe, is an ergonomics improvement now that `Spi` is based on returning Results.  And this is a thing we need to do know as it's a backwards incompatible ABI change along with a backwards incompatible code change.