### PR TITLE
On Linux, `dlopen()` user functions from a memory-mapped file 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +685,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -697,6 +734,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memfd"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memoffset"
@@ -1041,6 +1087,7 @@ dependencies = [
  "color-eyre",
  "eyre",
  "libloading",
+ "memfd",
  "once_cell",
  "pgx",
  "pgx-pg-config",
@@ -1339,6 +1386,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.14",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -28,6 +28,7 @@ target_postgrestd = []
 cfg-if = "1" # platform conditional helper
 once_cell = "1.7.2" # polyfills a nightly feature
 semver = "1.0.14"
+memfd = "0.6.2" # for loading user function .so
 
 # pgx core details
 pgx = { version = "0.7.0-beta.0" }

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -28,7 +28,6 @@ target_postgrestd = []
 cfg-if = "1" # platform conditional helper
 once_cell = "1.7.2" # polyfills a nightly feature
 semver = "1.0.14"
-memfd = "0.6.2" # for loading user function .so
 
 # pgx core details
 pgx = { version = "0.7.0-beta.0" }
@@ -53,6 +52,10 @@ prettyplease = "0.1"
 syn = "1"
 quote = "1"
 proc-macro2 = "1"
+
+[target.'cfg(target_os="linux")'.dependenciesa]
+memfd = "0.6.2" # for anonymously writing/loading user function .so
+
 
 [dev-dependencies]
 pgx-tests = { version = "0.7.0-beta.0" }

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -53,7 +53,7 @@ syn = "1"
 quote = "1"
 proc-macro2 = "1"
 
-[target.'cfg(target_os="linux")'.dependenciesa]
+[target.'cfg(target_os="linux")'.dependencies]
 memfd = "0.6.2" # for anonymously writing/loading user function .so
 
 

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -907,6 +907,18 @@ mod tests {
         assert_eq!(Ok(Some(1)), Spi::get_one::<i32>("SELECT fn1(1)"));
         Ok(())
     }
+
+    #[pg_test]
+    fn replace_function() -> spi::Result<()> {
+        Spi::run("CREATE FUNCTION replace_me() RETURNS int LANGUAGE plrust AS $$ Some(1) $$")?;
+        assert_eq!(Ok(Some(1)), Spi::get_one("SELECT replace_me()"));
+
+        Spi::run(
+            "CREATE OR REPLACE FUNCTION replace_me() RETURNS int LANGUAGE plrust AS $$ Some(2) $$",
+        )?;
+        assert_eq!(Ok(Some(2)), Spi::get_one("SELECT replace_me()"));
+        Ok(())
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -35,11 +35,10 @@ impl FnReady {
             mfd.as_file().set_len(shared_object.len() as u64)?;
             mfd.add_seals(&[memfd::FileSeal::SealShrink, memfd::FileSeal::SealGrow])?;
             mfd.add_seal(memfd::FileSeal::SealSeal)?;
+            mfd.as_file().write_all(&shared_object)?;
 
             let raw_fd = mfd.as_raw_fd();
             let filename = format!("/proc/self/fd/{raw_fd}");
-            let mut file = std::fs::File::open(&filename)?;
-            file.write_all(&shared_object)?;
             unsafe { Library::new(&filename)? }
         } else {
             // we write the shared object (`so`) bytes out to a temporary file rooted in our

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -5,11 +5,6 @@ use crate::user_crate::CrateState;
 
 impl CrateState for FnReady {}
 
-#[cfg(target_os = "linux")]
-type FileHolder = memfd::Memfd;
-#[cfg(not(target_os = "linux"))]
-type FileHolder = ();
-
 /// Ready-to-evaluate PL/Rust function
 ///
 /// - Requires: dlopened artifact
@@ -26,7 +21,12 @@ pub(crate) struct FnReady {
     // mainly, this is to hold the `Memfd` instance on Linux so that we can support
     // loading more than one user function .so at a time.  Linux seems to have a memory
     // of what it dlopen()'d based on the file descriptor number
-    _file_holder: FileHolder,
+    //
+    // and it's different based on platform!
+    #[cfg(target_os = "linux")]
+    _file_holder: memfd::Memfd,
+    #[cfg(not(target_os = "linux"))]
+    _file_holder: (),
 }
 
 impl FnReady {

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -29,14 +29,14 @@ impl FnReady {
         shared_object: Vec<u8>,
     ) -> eyre::Result<Self> {
         let library = if cfg!(target_os = "linux") {
-            use std::os::unix::io::IntoRawFd;
+            use std::os::unix::io::AsRawFd;
             let options = memfd::MemfdOptions::default().allow_sealing(true);
             let mfd = options.create(&format!("plrust-fn-{db_oid}-{fn_oid}"))?;
             mfd.as_file().set_len(shared_object.len() as u64)?;
             mfd.add_seals(&[memfd::FileSeal::SealShrink, memfd::FileSeal::SealGrow])?;
             mfd.add_seal(memfd::FileSeal::SealSeal)?;
 
-            let raw_fd = mfd.into_file().into_raw_fd();
+            let raw_fd = mfd.as_file().as_raw_fd();
             let filename = format!("/proc/self/fd/{raw_fd}");
             let mut file = std::fs::File::open(&filename)?;
             file.write_all(&shared_object)?;

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -36,7 +36,7 @@ impl FnReady {
             mfd.add_seals(&[memfd::FileSeal::SealShrink, memfd::FileSeal::SealGrow])?;
             mfd.add_seal(memfd::FileSeal::SealSeal)?;
 
-            let raw_fd = mfd.as_file().as_raw_fd();
+            let raw_fd = mfd.as_raw_fd();
             let filename = format!("/proc/self/fd/{raw_fd}");
             let mut file = std::fs::File::open(&filename)?;
             file.write_all(&shared_object)?;

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -36,7 +36,7 @@ impl FnReady {
             mfd.add_seals(&[memfd::FileSeal::SealShrink, memfd::FileSeal::SealGrow])?;
             mfd.add_seal(memfd::FileSeal::SealSeal)?;
 
-            let raw_fd = mfd.as_file().into_raw_fd();
+            let raw_fd = mfd.into_file().into_raw_fd();
             let filename = format!("/proc/self/fd/{raw_fd}");
             let mut file = std::fs::File::open(&filename)?;
             file.write_all(&shared_object)?;

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -40,14 +40,7 @@ impl FnReady {
             let filename = format!("/proc/self/fd/{raw_fd}");
             let mut file = std::fs::File::open(&filename)?;
             file.write_all(&shared_object)?;
-            let library = unsafe { Library::new(&filename)? };
-
-            // just to be obvious, the `memfd` instance gets dropped here.  Now that it's been loaded, we don't
-            // need it.  If any of the above failed and returned an Error, it'll still get dropped when
-            // the function returns.
-            drop(mfd);
-
-            library
+            unsafe { Library::new(&filename)? }
         } else {
             // we write the shared object (`so`) bytes out to a temporary file rooted in our
             // configured `plrust.work_dir`.  This will get removed from disk when this function

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -115,7 +115,7 @@ impl FnReady {
             symbol_name,
             library,
             symbol,
-            _file_holder,
+            _file_holder: file_holder,
         })
     }
 

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -1,6 +1,5 @@
 use libloading::os::unix::{Library, Symbol};
 use pgx::pg_sys;
-use std::io::Write;
 
 use crate::gucs;
 use crate::user_crate::CrateState;
@@ -35,7 +34,9 @@ impl FnReady {
             //
             // This is an added "safety" measure as we can (reasonably) assure ourselves that the
             // file won't be overwritten between when we finish writing it and when it is dlopen'd
+            use std::io::Write;
             use std::os::unix::io::AsRawFd;
+
             let mfd = memfd::MemfdOptions::default()
                 .allow_sealing(true)
                 .create(&format!("plrust-fn-{db_oid}-{fn_oid}-{pg_proc_xmin}"))?;

--- a/plrust/src/user_crate/ready.rs
+++ b/plrust/src/user_crate/ready.rs
@@ -21,7 +21,7 @@ pub(crate) struct FnReady {
 }
 
 impl FnReady {
-    // #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %db_oid, fn_oid = %fn_oid))]
+    #[tracing::instrument(level = "debug", skip_all, fields(db_oid = %db_oid, fn_oid = %fn_oid))]
     pub(crate) unsafe fn load(
         pg_proc_xmin: pg_sys::TransactionId,
         db_oid: pg_sys::Oid,


### PR DESCRIPTION
When running on Linux we create an anonymous file (via `memfd_create()`), write the user function shared library bytes to it, and "dlopen()" from there.

On all other platforms we maintain our current solution of writing a temporary file to the configured `plrust.work_dir`.