### PR TITLE
Hack for multi-target postgrestd

### DIFF
--- a/plrust/build
+++ b/plrust/build
@@ -1,8 +1,8 @@
-#! /usr/bin/sh
+#!/usr/bin/env bash
 set -xe
 
-if [ -z "$PLRUST_TARGET" ]; then
-    export PLRUST_TARGET="x86_64-postgres-linux-gnu"
+if [ -z "$PLRUST_TARGETS" ]; then
+    export PLRUST_TARGETS="x86_64-postgres-linux-gnu aarch64-postgres-linux-gnu"
 fi
 
 # Make sure the tip of pgx's develop branch is used,
@@ -24,12 +24,12 @@ fi
         git pull
         git submodule update --init --recursive
     else
-        git clone https://github.com/tcdi/postgrestd.git --branch "1.65-vendor-postgres" --recurse-submodules
+        git clone https://github.com/tcdi/postgrestd.git --branch "thomcc/multi-target" --recurse-submodules
         cd ./postgrestd
     fi
     rm --force rust-toolchain.toml
-    ./run clean
-    STD_TARGET="$PLRUST_TARGET" ./run install
+    STD_TARGETS="$PLRUST_TARGETS" ./run clean
+    STD_TARGETS="$PLRUST_TARGETS" ./run install
 )
 
 cargo test --verbose --no-default-features --features "pg${PG_VER:-15} target_postgrestd"


### PR DESCRIPTION
To use this make sure that if you're on x86_64, then the environment is like
- `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc`
- `CARGO_TARGET_AARCH64_POSTGRES_LINUX_GNU_LINKER=<same thing>`
And vice versa for x86_64. Then it should work. Depends on https://github.com/tcdi/postgrestd/pull/18