### PR TITLE
upgrade pgx dependency to 0.7.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35dbbc50ba1bced07cd4afbae2b474f8e3a7c9b6dcbe6554496462cb4125e06"
+checksum = "7842edd5c1d320ab9e96a63f6852a7447dbe17ee4557270c46a04fff02b5f934"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe4170846d14b5d232e6d70745f1a0a0d519b52c74a0cebe6e04f71c3e8560"
+checksum = "e5e1ebc8da263325cbe265b953b5822194579e3c3b08264a6161349f9529d3fb"
 dependencies = [
  "pgx-sql-entity-graph",
  "proc-macro2",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f46b8ab68c98e26603efb6da17bda1534e5089fea0a122f31cad9fc58f6a93"
+checksum = "8159b647485d6c9c4bd43df812aaa122fdac890b54c6c4f2d390886a6d2fee32"
 dependencies = [
  "dirs",
  "eyre",
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfd9ef9a477fedbc914f05186f5c042b686f7774d5fae866959cce28b9fdd6f"
+checksum = "ab0015dfb9b9e51a5f3aff67433d5abf8473aba2e44225152cd2d000b639c075"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-sql-entity-graph"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ab108b5805483a6f91d08fabcdff8432533973a52ad4f4b30eebfee2cbc459"
+checksum = "5ec050ace06a83202a9c1031f3fd39a77262cd2af79296788b7f69fcda8916f8"
 dependencies = [
  "convert_case",
  "cstr_core",
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.7.0-beta.0"
+version = "0.7.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f433087118ed8565eab181ef78645bfaf695fcac9509e542f60a940f965677"
+checksum = "36fb73d293f3071a16bed81c142acafb0885925a283fb4adf03f3b5ca3ff43e0"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd303550875ba33b137a7c93318cfdeb54c95e63ff7a0982d28425d3f87552c"
+checksum = "c215311383d25d03753375c53ab9fad8fc0cf46953c409211e065edeabf577ee"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -30,8 +30,8 @@ once_cell = "1.7.2" # polyfills a nightly feature
 semver = "1.0.14"
 
 # pgx core details
-pgx = { version = "0.7.0-beta.0" }
-pgx-pg-config = { version = "0.7.0-beta.0" }
+pgx = { version = "0.7.0-beta.1" }
+pgx-pg-config = { version = "0.7.0-beta.1" }
 
 # language handler support
 libloading = "0.7.2"
@@ -58,7 +58,7 @@ memfd = "0.6.2" # for anonymously writing/loading user function .so
 
 
 [dev-dependencies]
-pgx-tests = { version = "0.7.0-beta.0" }
+pgx-tests = { version = "0.7.0-beta.1" }
 tempdir = "0.3.7"
 once_cell = "1.7.2"
 toml = "0.5.8"

--- a/plrust/build
+++ b/plrust/build
@@ -11,7 +11,7 @@ cargo update -p pgx
 cargo fetch
 if [ "$CI" != true ]; then
     cargo install cargo-pgx \
-     --version "0.7.0-beta.0" \
+     --version "0.7.0-beta.1" \
      --locked # use the Cargo.lock in the pgx repo
 fi
 

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -277,7 +277,7 @@ pub(crate) fn cargo_toml_template(crate_name: &str, version_feature: &str) -> to
         crate-type = ["cdylib"]
 
         [dependencies]
-        pgx =  { git = "https://github.com/tcdi/plrust", branch = "trusted-pgx", package = "trusted-pgx" }
+        pgx =  { git = "https://github.com/tcdi/plrust", branch = "main", package = "trusted-pgx" }
         // pallocator = { version = "0.1.0", git = "https://github.com/tcdi/postgrestd", branch = "1.61" }
 
         /* User deps added here */

--- a/trusted-pgx/Cargo.toml
+++ b/trusted-pgx/Cargo.toml
@@ -17,4 +17,4 @@ pg14 = ["pgx/pg14"]
 pg15 = ["pgx/pg15"]
 
 [dependencies]
-pgx = { version = "0.7.0-beta.0", features = [ "no-schema-generation", "plrust" ], default-features = false }
+pgx = { version = "0.7.0-beta.1", features = [ "no-schema-generation", "plrust" ], default-features = false }


### PR DESCRIPTION
This also changes the expected branch for the "trusted-pgx" dependency to the `main` branch.

~~Because of that change, CI is going to fail.  But I'll merge anyways and then it should pass in the main branch.  Tests pass locally for me.~~

No, it shouldn't.  That crate is already in `main`.  