### PR TITLE
Only specify CARGO_TARGET_..._LINKER if not already specified, and ensure it and `STD_TARGETS` are exported and avaliable to `./run`.

### DIFF
--- a/plrust/build
+++ b/plrust/build
@@ -3,17 +3,21 @@ set -xe
 
 if [ -z "$STD_TARGETS" ]; then
     # if none specified, always build for these two targets
-    STD_TARGETS="x86_64-postgres-linux-gnu aarch64-postgres-linux-gnu"
+    export STD_TARGETS="x86_64-postgres-linux-gnu aarch64-postgres-linux-gnu"
 fi
 
 # and depending on the platform we're building on, we need to set a linker flag for the other
 # this'll get hairy when we support more platforms and we should port this script to Rust
 if [ `uname -m` == "x86_64" ]; then
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-    CARGO_TARGET_AARCH64_POSTGRES_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    if [[ -z "$CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER" ]] && [[ -z "$CARGO_TARGET_AARCH64_POSTGRES_LINUX_GNU_LINKER" ]]; then
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+        export CARGO_TARGET_AARCH64_POSTGRES_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    fi
 elif [ `uname -m` == "aarch64" ]; then
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
-    CARGO_TARGET_X86_64_POSTGRES_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+    if [[ -z "$CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER" ]] && [[ -z "$CARGO_TARGET_X86_64_POSTGRES_LINUX_GNU_LINKER" ]]; then
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+        export CARGO_TARGET_X86_64_POSTGRES_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+    fi
 else
     echo unsupported build platform: $(uname -m)
     exit 1

--- a/plrust/build
+++ b/plrust/build
@@ -3,7 +3,7 @@ set -xe
 
 if [ -z "$STD_TARGETS" ]; then
     # if none specified, always build for these two targets
-    export STD_TARGETS="x86_64-postgres-linux-gnu aarch64-postgres-linux-gnu"
+    STD_TARGETS="x86_64-postgres-linux-gnu aarch64-postgres-linux-gnu"
 fi
 
 # and depending on the platform we're building on, we need to set a linker flag for the other
@@ -46,8 +46,8 @@ fi
         cd ./postgrestd
     fi
     rm --force rust-toolchain.toml
-    ./run clean
-    ./run install
+    STD_TARGETS="$STD_TARGETS" ./run clean
+    STD_TARGETS="$STD_TARGETS" ./run install
 )
 
 cargo test --verbose --no-default-features --features "pg${PG_VER:-15} trusted"


### PR DESCRIPTION
Reported on discord.