### PR TITLE
Remove the `plrust.pg_config` GUC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,6 @@ dependencies = [
  "memfd",
  "once_cell",
  "pgx",
- "pgx-pg-config",
  "pgx-tests",
  "prettyplease",
  "proc-macro2",

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ The other available configuration, some of which are **required** are:
 
 | Option                             | Type   | Description                                                 | Required | Default                   |
 | ---------------------------------- | ------ | ----------------------------------------------------------- | -------- | ------------------------- |
-| `plrust.pg_config`                 | string | The full path of the `pg_config` binary                     | yes      | <none>                    |
 | `plrust.work_dir`                  | string | The directory where pl/rust will build functions with cargo | yes      | <none>                    |
 | `plrust.tracing_level`             | string | A [tracing directive][docs-rs-tracing-directive]            | no       | `'info'`                  |
 | `plrust.compilation_targets`       | string | Comma separated list of CPU targets (x86_64, aarch64)       | no       | <none>                    |
@@ -243,10 +242,8 @@ $ cd plrust/plrust
 $ cargo pgx run pg14
 psql> \q
 
-$ PG_CONFIG=$(find ~/.pgx/14.*/pgx-install/bin/pg_config)
 $ SCRATCH_DIR=/home/${USER}/plrust-scratch
 $ cat <<-EOF >> ~/.pgx/data-14/postgresql.conf
-  plrust.pg_config = '${PG_CONFIG}'
   plrust.work_dir = '${SCRATCH_DIR}'
 EOF
 $ mkdir -p scratch

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -38,7 +38,6 @@ serde_json = "1.0.91"
 
 # pgx core details
 pgx = { version = "0.7.0" }
-pgx-pg-config = { version = "0.7.0" }
 
 # language handler support
 libloading = "0.7.2"

--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -20,7 +20,6 @@ use crate::target;
 use crate::target::{CompilationTarget, CrossCompilationTarget, TargetErr};
 
 static PLRUST_WORK_DIR: GucSetting<Option<&'static str>> = GucSetting::new(None);
-static PLRUST_PG_CONFIG: GucSetting<Option<&'static str>> = GucSetting::new(None);
 static PLRUST_TRACING_LEVEL: GucSetting<Option<&'static str>> = GucSetting::new(None);
 pub(crate) static PLRUST_ALLOWED_DEPENDENCIES: GucSetting<Option<&'static str>> =
     GucSetting::new(None);
@@ -47,14 +46,6 @@ pub(crate) fn init() {
         "The directory where pl/rust will build functions with cargo",
         "The directory where pl/rust will build functions with cargo",
         &PLRUST_WORK_DIR,
-        GucContext::Sighup,
-    );
-
-    GucRegistry::define_string_guc(
-        "plrust.pg_config",
-        "What is the full path to the `pg_config` tool for this Postgres installation?",
-        "What is the full path to the `pg_config` tool for this Postgres installation?",
-        &PLRUST_PG_CONFIG,
         GucContext::Sighup,
     );
 
@@ -90,15 +81,6 @@ pub(crate) fn work_dir() -> PathBuf {
             .expect("plrust.work_dir is not set in postgresql.conf"),
     )
     .expect("plrust.work_dir is not a valid path")
-}
-
-pub(crate) fn pg_config() -> PathBuf {
-    PathBuf::from_str(
-        &PLRUST_PG_CONFIG
-            .get()
-            .expect("plrust.pg_config is not set in postgresql.conf"),
-    )
-    .expect("plrust.pg_config is not a valid path")
 }
 
 pub(crate) fn tracing_level() -> tracing::Level {

--- a/plrust/src/plrust.rs
+++ b/plrust/src/plrust.rs
@@ -100,7 +100,6 @@ pub(crate) unsafe fn evaluate_function(
 #[tracing::instrument(level = "debug")]
 pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let work_dir = gucs::work_dir();
-    let pg_config = gucs::pg_config();
     let target_dir = work_dir.join("target");
     // SAFETY: Postgres globally sets this to `const InvalidOid`, so is always read-safe,
     // then writes it only during initialization, so we should not be racing anyone.
@@ -110,7 +109,7 @@ pub(crate) fn compile_function(fn_oid: pg_sys::Oid) -> eyre::Result<Output> {
     let provisioned = generated.provision(&work_dir)?;
     // We want to introduce validation here.
     let crate_dir = provisioned.crate_dir().to_path_buf();
-    let (validated, _output) = provisioned.validate(pg_config, target_dir.as_path())?;
+    let (validated, _output) = provisioned.validate(target_dir.as_path())?;
     let target_builds = validated.build(target_dir.as_path())?;
 
     // we gotta have at least one built crate and it's for this host's target triple

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -862,19 +862,11 @@ mod tests {
 #[cfg(any(test, feature = "pg_test"))]
 pub mod pg_test {
     use once_cell::sync::Lazy;
-    use pgx_pg_config::Pgx;
     use tempdir::TempDir;
 
     static WORK_DIR: Lazy<String> = Lazy::new(|| {
         let work_dir = TempDir::new("plrust-tests").expect("Couldn't create tempdir");
         format!("plrust.work_dir='{}'", work_dir.path().display())
-    });
-    static PG_CONFIG: Lazy<String> = Lazy::new(|| {
-        let pgx_config = Pgx::from_config().unwrap();
-        let version = format!("pg{}", pgx::pg_sys::get_pg_major_version_num());
-        let pg_config = pgx_config.get(&version).unwrap();
-        let path = pg_config.path().unwrap();
-        format!("plrust.pg_config='{}'", path.as_path().display())
     });
     static LOG_LEVEL: &str = "plrust.tracing_level=trace";
 
@@ -917,7 +909,6 @@ tokio = { version = "1.19.2", features = ["rt", "net"]}"#
     pub fn postgresql_conf_options() -> Vec<&'static str> {
         vec![
             &*WORK_DIR,
-            &*PG_CONFIG,
             &*LOG_LEVEL,
             &*PLRUST_ALLOWED_DEPENDENCIES,
             "shared_preload_libraries='plrust'",

--- a/plrust/src/user_crate/build.rs
+++ b/plrust/src/user_crate/build.rs
@@ -111,7 +111,7 @@ impl FnBuild {
         //
         // This turned out to be an unwanted bit of user, system, and operational complexity.
         //
-        // Instead, we tell tell the environment that "pg_config" is described as environment
+        // Instead, we tell the environment that "pg_config" is described as environment
         // variables, and set every property Postgres can tell us (which is essentially how
         // `pg_config` itself works) as individual environment variables, each prefixed with
         // "PGX_PG_CONFIG_".

--- a/plrust/src/user_crate/build.rs
+++ b/plrust/src/user_crate/build.rs
@@ -6,6 +6,7 @@ All rights reserved.
 Use of this source code is governed by the PostgreSQL license that can be found in the LICENSE.md file.
 */
 
+use std::ffi::CStr;
 use std::{
     path::{Path, PathBuf},
     process::{Command, Output},
@@ -13,7 +14,7 @@ use std::{
 
 use color_eyre::{Section, SectionExt};
 use eyre::{eyre, WrapErr};
-use pgx::pg_sys;
+use pgx::{pg_sys, PgMemoryContexts};
 
 use crate::target::{CompilationTarget, CrossCompilationTarget};
 use crate::{
@@ -33,7 +34,6 @@ pub(crate) struct FnBuild {
     fn_oid: pg_sys::Oid,
     crate_name: String,
     crate_dir: PathBuf,
-    pg_config: PathBuf,
 }
 
 impl CrateState for FnBuild {}
@@ -46,7 +46,6 @@ impl FnBuild {
         fn_oid: pg_sys::Oid,
         crate_name: String,
         crate_dir: PathBuf,
-        pg_config: PathBuf,
     ) -> Self {
         Self {
             pg_proc_xmin,
@@ -54,7 +53,6 @@ impl FnBuild {
             fn_oid,
             crate_name,
             crate_dir,
-            pg_config,
         }
     }
 
@@ -105,9 +103,26 @@ impl FnBuild {
         command.arg("--release");
         command.arg("--target");
         command.arg(&target_triple);
-        command.env("PGX_PG_CONFIG_PATH", &self.pg_config);
         command.env("CARGO_TARGET_DIR", &cargo_target_dir);
         command.env("RUSTFLAGS", "-Clink-args=-Wl,-undefined,dynamic_lookup");
+
+        // There was a time in the past where plrust had a `plrust.pg_config` GUC whose value was
+        // passed down to the "pgx-pg-sys" transient dependency via an environment variable.
+        //
+        // This turned out to be an unwanted bit of user, system, and operational complexity.
+        //
+        // Instead, we tell tell the environment that "pg_config" is described as environment
+        // variables, and set every property Postgres can tell us (which is essentially how
+        // `pg_config` itself works) as individual environment variables, each prefixed with
+        // "PGX_PG_CONFIG_".
+        //
+        // "pgx-pg-sys"'s build.rs knows how to interpret these environment variables to get what
+        // it needs to properly generate bindings.
+        command.env("PGX_PG_CONFIG_AS_ENV", "true");
+        for (k, v) in pg_config_values() {
+            let k = format!("PGX_PG_CONFIG_{k}");
+            command.env(k, v);
+        }
 
         // set environment variables we need in order for a cross compile
         if let Some(target_triple) = cross_compilation_target {
@@ -190,5 +205,41 @@ impl FnBuild {
     // for #[tracing] purposes
     pub(crate) fn crate_dir(&self) -> &Path {
         &self.crate_dir
+    }
+}
+
+/// Asks Postgres, via FFI, for all of its compile-time configuration data.  This is the full
+/// set of things that Postgres' `pg_config` configuration tool can report.
+///
+/// The returned tuple is a `(key, value)` pair of the configuration name and its value.
+fn pg_config_values() -> impl Iterator<Item = (String, String)> {
+    unsafe {
+        // SAFETY:  we know the memory context we're switching to is valid because we're also making
+        // it right here.  We're also responsible for pfreeing the result of `get_configdata()` and
+        // the easiest way to do that is to simply free an entire memory context at once
+        PgMemoryContexts::new("configdata").switch_to(|_| {
+            let mut nprops = 0;
+            // SAFETY:  `get_configdata` needs to know where the "postmaster" executable is located
+            // and `pg_sys::my_exec_path` is that global, which Postgres assigns once early in its
+            // startup process
+            let configdata = pg_sys::get_configdata(pg_sys::my_exec_path.as_ptr(), &mut nprops);
+
+            // SAFETY:  `get_configdata` will never return the NULL pointer
+            let slice = std::slice::from_raw_parts(configdata, nprops);
+
+            let mut values = Vec::with_capacity(nprops);
+            for e in slice {
+                // SAFETY:  the members (we use) in `ConfigData` are properly allocated char pointers,
+                // done so by the `get_configdata()` call above
+                let name = CStr::from_ptr(e.name);
+                let setting = CStr::from_ptr(e.setting);
+                values.push((
+                    name.to_string_lossy().to_string(),
+                    setting.to_string_lossy().to_string(),
+                ))
+            }
+
+            values.into_iter()
+        })
     }
 }

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -36,10 +36,7 @@ use pgx::{pg_sys, PgBuiltInOids, PgOid};
 use proc_macro2::TokenStream;
 use quote::quote;
 use semver;
-use std::{
-    path::{Path, PathBuf},
-    process::Output,
-};
+use std::{path::Path, process::Output};
 
 /**
 Finite state machine with "typestate" generic
@@ -123,13 +120,9 @@ impl UserCrate<FnVerify> {
             crate_dir = %self.0.crate_dir().display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub fn validate(
-        self,
-        pg_config: PathBuf,
-        target_dir: &Path,
-    ) -> eyre::Result<(UserCrate<FnBuild>, Output)> {
+    pub fn validate(self, target_dir: &Path) -> eyre::Result<(UserCrate<FnBuild>, Output)> {
         self.0
-            .validate(pg_config, target_dir)
+            .validate(target_dir)
             .map(|(state, output)| (UserCrate(state), output))
     }
 
@@ -390,7 +383,6 @@ mod tests {
             let fn_oid = pg_sys::Oid::INVALID;
             let db_oid = unsafe { pg_sys::MyDatabaseId };
             let target_dir = crate::gucs::work_dir();
-            let pg_config = PathBuf::from(crate::gucs::pg_config());
 
             let variant = {
                 let argument_oids_and_names =
@@ -469,7 +461,7 @@ mod tests {
 
             let provisioned = generated.provision(&target_dir)?;
 
-            let (validated, _output) = provisioned.validate(pg_config, &target_dir)?;
+            let (validated, _output) = provisioned.validate(&target_dir)?;
 
             for (built, _output) in validated.build(&target_dir)? {
                 // Without an fcinfo, we can't call this.

--- a/plrust/src/user_crate/verify.rs
+++ b/plrust/src/user_crate/verify.rs
@@ -24,7 +24,6 @@ allows using the linting power of rustc on it as a validation step.
 Then the function can be rewritten with annotations from pgx-macros injected.
 */
 
-use crate::target;
 use crate::user_crate::{CrateState, FnBuild, PlRustError};
 use eyre::{eyre, WrapErr};
 use pgx::pg_sys;
@@ -75,11 +74,7 @@ impl FnVerify {
             crate_dir = %self.crate_dir.display(),
             target_dir = tracing::field::display(target_dir.display()),
         ))]
-    pub(crate) fn validate(
-        self,
-        pg_config: PathBuf,
-        target_dir: &Path,
-    ) -> eyre::Result<(FnBuild, Output)> {
+    pub(crate) fn validate(self, target_dir: &Path) -> eyre::Result<(FnBuild, Output)> {
         // This is the step which would be used for running validation
         // after writing the lib.rs but before actually building it.
         // As PL/Rust is not fully configured to run user commands here,
@@ -98,7 +93,6 @@ impl FnVerify {
                     self.fn_oid,
                     self.crate_name,
                     self.crate_dir,
-                    pg_config,
                 ),
                 output,
             ))


### PR DESCRIPTION
Turns out Postgres itself, via its internal `get_configdata()` function knows everything `pg_config` does.  So we convert all the `ConfigData` key/value pairs into environment variables for pgx-pg-sys to use during its build.rs.  

This relies on the changes in https://github.com/tcdi/pgx/pull/1019 and https://github.com/tcdi/pgx/pull/1020.