### PR TITLE
fix issue #183

### DIFF
--- a/plrust/src/hooks.rs
+++ b/plrust/src/hooks.rs
@@ -88,7 +88,8 @@ fn plrust_process_utility_hook_internal(
         //
         // plrust must be configured as a `shared_preload_libraries` entry, so this hook will be
         // running in every database, including those without the plrust extension
-        return;
+        #[rustfmt::skip]
+        return call_prev_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
     }
 
     let pstmt = unsafe {

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -58,16 +58,6 @@ use pgx::{pg_getarg, prelude::*};
 pub use tests::pg_test;
 pgx::pg_module_magic!();
 
-/// this function will raise an ERROR if the `plrust` language isn't installed
-pub(crate) fn plrust_lang_oid() -> Option<pg_sys::Oid> {
-    static PLRUST_LANG_NAME: &[u8] = b"plrust\0"; // want this to look like a c string
-
-    // SAFETY: We pass `missing_ok: false`, which will cause an error if not found.
-    // So we always will return a valid Oid if we return at all.
-    // The first parameter has the same requirements as `&CStr`.
-    Some(unsafe { pg_sys::get_language_oid(PLRUST_LANG_NAME.as_ptr().cast(), false) })
-}
-
 #[pg_guard]
 fn _PG_init() {
     // Must be loaded with shared_preload_libraries


### PR DESCRIPTION
`plrust` will no longer raise an ERROR if a function is being ALTERed in a database that doesn't also have the `plrust` extension created.