### PR TITLE
Set a `$PATH` when there isn't one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,9 +1120,9 @@ dependencies = [
  "base64 0.21.0",
  "cfg-if",
  "color-eyre",
- "dirs",
  "eyre",
  "flate2",
+ "home",
  "libloading",
  "memfd",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ dependencies = [
  "base64 0.21.0",
  "cfg-if",
  "color-eyre",
+ "dirs",
  "eyre",
  "flate2",
  "libloading",

--- a/README.md
+++ b/README.md
@@ -201,15 +201,16 @@ Failure to do so will cause the plrust extension to raise an ERROR whenever Post
 
 The other available configuration, some of which are **required** are:
 
-| Option                             | Type   | Description                                                 | Required | Default                   |
-| ---------------------------------- | ------ | ----------------------------------------------------------- | -------- | ------------------------- |
-| `plrust.work_dir`                  | string | The directory where pl/rust will build functions with cargo | yes      | <none>                    |
-| `plrust.tracing_level`             | string | A [tracing directive][docs-rs-tracing-directive]            | no       | `'info'`                  |
-| `plrust.compilation_targets`       | string | Comma separated list of CPU targets (x86_64, aarch64)       | no       | <none>                    |
-| `plrust.x86_64_linker`             | string | Name of the linker `rustc` should use on fo cross-compile   | no       | `'x86_64_linux_gnu_gcc'`  |
-| `plrust.aarch64_linker`            | string | Name of the linker `rustc` should use on for cross-compile  | no       | `'aarch64_linux_gnu_gcc'` |
-| `plrust.x86_64_pgx_bindings_path`  | string | Path to output from `cargo pgx cross pgx-target` on x86_64  | no-ish   | <none>                    |
-| `plrust.aarch64_pgx_bindings_path` | string | Path to output form `cargo pgx cross pgx-target` on aarch64 | no-ish   | <none>                    |
+| Option                             | Type   | Description                                                        | Required | Default                                                    |
+|------------------------------------| ------ |--------------------------------------------------------------------|----------|------------------------------------------------------------|
+| `plrust.work_dir`                  | string | The directory where pl/rust will build functions with cargo        | yes      | <none>                                                     |
+| `plrust.PATH_override`             | string | If `cargo` and `cc` aren't in the `postmaster`'s `$PATH`, set this | no       | environment or `~/.cargo/bin:/usr/bin` if `$PATH` is unset |
+| `plrust.tracing_level`             | string | A [tracing directive][docs-rs-tracing-directive]                   | no       | `'info'`                                                   |
+| `plrust.compilation_targets`       | string | Comma separated list of CPU targets (x86_64, aarch64)              | no       | <none>                                                     |
+| `plrust.x86_64_linker`             | string | Name of the linker `rustc` should use on fo cross-compile          | no       | `'x86_64_linux_gnu_gcc'`                                   |
+| `plrust.aarch64_linker`            | string | Name of the linker `rustc` should use on for cross-compile         | no       | `'aarch64_linux_gnu_gcc'`                                  |
+| `plrust.x86_64_pgx_bindings_path`  | string | Path to output from `cargo pgx cross pgx-target` on x86_64         | no-ish   | <none>                                                     |
+| `plrust.aarch64_pgx_bindings_path` | string | Path to output form `cargo pgx cross pgx-target` on aarch64        | no-ish   | <none>                                                     |
 
 For PL/Rust to cross compile user functions it needs to know which CPU architectures via
 `plrust.compilation_targets`. This is a comma-separated list of values, of which only `x86_64` and `aarch64` are

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -29,7 +29,7 @@ force_enable_x86_64_darwin_generations = []
 cfg-if = "1" # platform conditional helper
 once_cell = "1.7.2" # polyfills a nightly feature
 semver = "1.0.14"
-dirs = "4.0.0" # where might our home directory be?
+home = "0.5.4" # where can we find cargo?
 
 # working with our entry in pg_catalog.pg_proc
 base64 = "0.21.0"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -29,6 +29,7 @@ force_enable_x86_64_darwin_generations = []
 cfg-if = "1" # platform conditional helper
 once_cell = "1.7.2" # polyfills a nightly feature
 semver = "1.0.14"
+dirs = "4.0.0" # where might our home directory be?
 
 # working with our entry in pg_catalog.pg_proc
 base64 = "0.21.0"

--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -20,6 +20,7 @@ use crate::target;
 use crate::target::{CompilationTarget, CrossCompilationTarget, TargetErr};
 
 static PLRUST_WORK_DIR: GucSetting<Option<&'static str>> = GucSetting::new(None);
+pub(crate) static PLRUST_PATH_OVERRIDE: GucSetting<Option<&'static str>> = GucSetting::new(None);
 static PLRUST_TRACING_LEVEL: GucSetting<Option<&'static str>> = GucSetting::new(None);
 pub(crate) static PLRUST_ALLOWED_DEPENDENCIES: GucSetting<Option<&'static str>> =
     GucSetting::new(None);
@@ -48,6 +49,13 @@ pub(crate) fn init() {
         &PLRUST_WORK_DIR,
         GucContext::Sighup,
     );
+
+    GucRegistry::define_string_guc(
+          "plrust.PATH_override", 
+          "The $PATH setting to use for building plrust user functions",
+          "It may be necessary to override $PATH in order to find compilation dependencies such as `cargo`, `cc`, etc",
+          &PLRUST_PATH_OVERRIDE,
+          GucContext::Sighup);
 
     GucRegistry::define_string_guc(
         "plrust.tracing_level",

--- a/plrust/src/user_crate/build.rs
+++ b/plrust/src/user_crate/build.rs
@@ -9,7 +9,7 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 use std::ffi::CStr;
 use std::{
     path::{Path, PathBuf},
-    process::{Command, Output},
+    process::Output,
 };
 
 use color_eyre::{Section, SectionExt};
@@ -17,6 +17,7 @@ use eyre::{eyre, WrapErr};
 use pgx::{pg_sys, PgMemoryContexts};
 
 use crate::target::{CompilationTarget, CrossCompilationTarget};
+use crate::user_crate::cargo;
 use crate::{
     gucs,
     user_crate::{CrateState, FnLoad},
@@ -96,7 +97,7 @@ impl FnBuild {
         target_triple: CompilationTarget,
         cross_compilation_target: Option<CrossCompilationTarget>,
     ) -> eyre::Result<(FnLoad, Output)> {
-        let mut command = Command::new("cargo");
+        let mut command = cargo();
 
         command.current_dir(&self.crate_dir);
         command.arg("rustc");
@@ -191,7 +192,7 @@ impl FnBuild {
                 }));
 
             // Clean up on error but don't let this error replace our user's error!
-            if let Err(e)= std::fs::remove_dir_all(&self.crate_dir) {
+            if let Err(e) = std::fs::remove_dir_all(&self.crate_dir) {
                 pgx::log!("Problem during removing crate directory: {e}")
             };
 

--- a/plrust/src/user_crate/build.rs
+++ b/plrust/src/user_crate/build.rs
@@ -97,7 +97,7 @@ impl FnBuild {
         target_triple: CompilationTarget,
         cross_compilation_target: Option<CrossCompilationTarget>,
     ) -> eyre::Result<(FnLoad, Output)> {
-        let mut command = cargo();
+        let mut command = cargo()?;
 
         command.current_dir(&self.crate_dir);
         command.arg("rustc");

--- a/plrust/src/user_crate/verify.rs
+++ b/plrust/src/user_crate/verify.rs
@@ -24,12 +24,12 @@ allows using the linting power of rustc on it as a validation step.
 Then the function can be rewritten with annotations from pgx-macros injected.
 */
 
-use crate::user_crate::{CrateState, FnBuild, PlRustError};
+use crate::user_crate::{cargo, CrateState, FnBuild, PlRustError};
 use eyre::{eyre, WrapErr};
 use pgx::pg_sys;
 use std::{
     path::{Path, PathBuf},
-    process::{Command, Output},
+    process::Output,
 };
 
 /// Available and ready-to-validate PL/Rust crate
@@ -79,7 +79,7 @@ impl FnVerify {
         // after writing the lib.rs but before actually building it.
         // As PL/Rust is not fully configured to run user commands here,
         // this version check just smoke-tests the ability to run a command
-        let mut command = Command::new("cargo");
+        let mut command = cargo();
         command.arg("--version");
         command.arg("--verbose");
 

--- a/plrust/src/user_crate/verify.rs
+++ b/plrust/src/user_crate/verify.rs
@@ -79,7 +79,7 @@ impl FnVerify {
         // after writing the lib.rs but before actually building it.
         // As PL/Rust is not fully configured to run user commands here,
         // this version check just smoke-tests the ability to run a command
-        let mut command = cargo();
+        let mut command = cargo()?;
         command.arg("--version");
         command.arg("--verbose");
 


### PR DESCRIPTION
Debian-based distro-managed Postgres installations (such as Ubuntu) seem to clear the `$PATH` environment variable when Postgres starts.  This means that plrust can't find the system commands such as `cargo` and `cc` that it needs to compile user functions (there are probably others).

If the `$PATH` is missing (or the empty string), we'll hardcode it to `~/.cargo/bin:/usr/bin` when executing `cargo`.  However, if the user has set the `plrust.PATH_override` GUC, then we will **always** use that when executing `cargo`.