### PR TITLE
bump version to 1.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plrust"
-version = "0.7.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "base64 0.21.0",
  "cfg-if",

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust"
-version = "0.7.0"
+version = "1.0.0-beta.1"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL Open Source License"

--- a/plrust/plrust.control
+++ b/plrust/plrust.control
@@ -1,4 +1,4 @@
-comment = 'plrust:  Created by pgx'
+comment = 'plrust:  A Trusted Rust procedural language for PostgreSQL'
 default_version = '1.0'
 module_pathname = '$libdir/plrust'
 relocatable = false

--- a/trusted-pgx/Cargo.toml
+++ b/trusted-pgx/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "trusted-pgx"
+# version set to match that of the pgx version it sits on top of, rather than matching plrust's version
 version = "0.7.1"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"


### PR DESCRIPTION
Bumps version numbers and updates Cargo metadata