### PR TITLE
Stop using LTO to build function crates

### DIFF
--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -276,8 +276,6 @@ pub(crate) fn cargo_toml_template(crate_name: &str, version_feature: &str) -> to
 
         [profile.release]
         debug-assertions = true
-        codegen-units = 1_usize
-        lto = "thin"
         opt-level = 3_usize
         panic = "unwind"
     }


### PR DESCRIPTION
This isn't necessary for compilation, causes problems, and massively slows down compilation.
We don't need to be using 1 CGU either.
These changes may penalize performance slightly. However, compilation times have been enough of a recurring concern that we must balance runtime and compilation time as we proceed.