### PR TITLE
Lint against `dyn Fn{,Mut,Once}`

### DIFF
--- a/LINTS.md
+++ b/LINTS.md
@@ -79,7 +79,7 @@ const SOMETHING: &str = include_str!("/etc/passwd");
 
 ## `plrust_fn_pointers`
 
-Currently, several soundness holes have to do wuth the interaction between function pointers, implied bounds, and nested references. As a stopgap against these, use of function pointer types and function trait objects are currently blocked. This lint will likely be made more precise in the future.
+Currently, several soundness holes have to do with the interaction between function pointers, implied bounds, and nested references. As a stopgap against these, use of function pointer types and function trait objects are currently blocked. This lint will likely be made more precise in the future.
 
 Note that function types (such as the types resulting from closures as required by iterator functions) are still allowed, as these do not have the issues around variance.
 

--- a/LINTS.md
+++ b/LINTS.md
@@ -79,7 +79,7 @@ const SOMETHING: &str = include_str!("/etc/passwd");
 
 ## `plrust_fn_pointers`
 
-Currently, several soundness holes have to do wuth the interaction between function pointers, implied bounds, and nested references. As a stopgap against these, use of function pointer types are currently blocked. This lint will likely be made more precise in the future.
+Currently, several soundness holes have to do wuth the interaction between function pointers, implied bounds, and nested references. As a stopgap against these, use of function pointer types and function trait objects are currently blocked. This lint will likely be made more precise in the future.
 
 Note that function types (such as the types resulting from closures as required by iterator functions) are still allowed, as these do not have the issues around variance.
 

--- a/plrustc/plrustc/src/lints.rs
+++ b/plrustc/plrustc/src/lints.rs
@@ -100,15 +100,38 @@ declare_lint_pass!(PlrustFnPointer => [PLRUST_FN_POINTERS]);
 
 impl<'tcx> LateLintPass<'tcx> for PlrustFnPointer {
     fn check_ty(&mut self, cx: &LateContext<'tcx>, ty: &hir::Ty) {
-        if let hir::TyKind::BareFn { .. } = &ty.kind {
-            // TODO: ideally this would just be cases where they accept or
-            // return nested references, however doing so is tricky, as it must
-            // pierce through `&'a SomeStruct(&'b InternalRef)`.
-            cx.lint(
-                PLRUST_FN_POINTERS,
-                "Use of function pointers is forbidden in PL/Rust",
-                |b| b.set_span(ty.span),
-            );
+        match &ty.kind {
+            hir::TyKind::BareFn { .. } => {
+                // TODO: ideally this would just be cases where they accept or
+                // return nested references, however doing so is tricky, as it must
+                // pierce through `&'a SomeStruct(&'b InternalRef)`.
+                cx.lint(
+                    PLRUST_FN_POINTERS,
+                    "Use of function pointers is forbidden in PL/Rust",
+                    |b| b.set_span(ty.span),
+                );
+            }
+            hir::TyKind::TraitObject(traits, ..) => {
+                for trayt in *traits {
+                    if let Some(did) = trayt.trait_ref.path.res.opt_def_id() {
+                        let fn_traits = [
+                            &["core", "ops", "function", "Fn"],
+                            &["core", "ops", "function", "FnMut"],
+                            &["core", "ops", "function", "FnOnce"],
+                        ];
+                        for fn_trait_paths in fn_traits {
+                            if match_def_path(cx, did, fn_trait_paths) {
+                                cx.lint(
+                                    PLRUST_FN_POINTERS,
+                                    "Use of function trait objects is forbidden in PL/Rust",
+                                    |b| b.set_span(ty.span),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/plrustc/plrustc/uitests/fn_traits.rs
+++ b/plrustc/plrustc/uitests/fn_traits.rs
@@ -1,0 +1,8 @@
+#![crate_type = "lib"]
+
+fn blah() {
+    let _a: &dyn Fn() = &|| {};
+    let _b: Box<dyn Fn()> = Box::new(|| println!("hello"));
+    let _c: Box<dyn FnMut()> = Box::new(|| println!("goodbye"));
+    let _d: Box<dyn FnOnce()> = Box::new(|| println!("..."));
+}

--- a/plrustc/plrustc/uitests/fn_traits.stderr
+++ b/plrustc/plrustc/uitests/fn_traits.stderr
@@ -1,0 +1,28 @@
+error: Use of function trait objects is forbidden in PL/Rust
+  --> $DIR/fn_traits.rs:4:14
+   |
+LL |     let _a: &dyn Fn() = &|| {};
+   |              ^^^^^^^^
+   |
+   = note: `-F plrust-fn-pointers` implied by `-F plrust-lints`
+
+error: Use of function trait objects is forbidden in PL/Rust
+  --> $DIR/fn_traits.rs:5:17
+   |
+LL |     let _b: Box<dyn Fn()> = Box::new(|| println!("hello"));
+   |                 ^^^^^^^^
+
+error: Use of function trait objects is forbidden in PL/Rust
+  --> $DIR/fn_traits.rs:6:17
+   |
+LL |     let _c: Box<dyn FnMut()> = Box::new(|| println!("goodbye"));
+   |                 ^^^^^^^^^^^
+
+error: Use of function trait objects is forbidden in PL/Rust
+  --> $DIR/fn_traits.rs:7:17
+   |
+LL |     let _d: Box<dyn FnOnce()> = Box::new(|| println!("..."));
+   |                 ^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Wasn't able to get any of these to work like function pointers do, but it seems like they have the same soundness holes nonetheless (which makes sense).