### PR TITLE
Add newline before closing block

### DIFF
--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -315,7 +315,7 @@ fn parse_source_and_deps(code_and_deps: &str) -> eyre::Result<(syn::Block, toml:
         }
     }
 
-    code_block.push_str(" }");
+    code_block.push_str("\n}");
 
     let user_dependencies = check_user_dependencies(deps_block)?;
 


### PR DESCRIPTION
Reported elsewhere. Trivial fix for something like:

```sql
create or replace function foo() returns text  IMMUTABLE STRICT  LANGUAGE PLRUST AS  $$
 [code]
     Ok(Some("foobar".to_string()))
 // $$;
```
