### PR TITLE
Support RETURNS TABLE

### DIFF
--- a/plrust/src/user_crate/crate_variant.rs
+++ b/plrust/src/user_crate/crate_variant.rs
@@ -6,9 +6,10 @@ All rights reserved.
 Use of this source code is governed by the PostgreSQL license that can be found in the LICENSE.md file.
 */
 
+use crate::pgproc::ProArgMode;
 use crate::{user_crate::oid_to_syn_type, PlRustError};
 use eyre::WrapErr;
-use pgx::PgOid;
+use pgx::{pg_sys, PgOid};
 use proc_macro2::{Ident, Span};
 use quote::quote;
 
@@ -35,16 +36,72 @@ pub(crate) enum CrateVariant {
 impl CrateVariant {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn function(
-        argument_oids_and_names: Vec<(PgOid, Option<String>)>,
+        argnames: Vec<Option<String>>,
+        argtypes: Vec<pg_sys::Oid>,
+        argmodes: Vec<ProArgMode>,
         return_oid: PgOid,
         return_set: bool,
         is_strict: bool,
     ) -> eyre::Result<Self> {
+        // we must have the same number of argument names, argument types, and modes  It's seemingly
+        // impossible that we never would, but lets make sure as it's an invariant from this
+        // point forward
+        assert_eq!(
+            argnames.len(),
+            argtypes.len(),
+            "mismatched argument names and types"
+        );
+        assert_eq!(
+            argnames.len(),
+            argmodes.len(),
+            "mismatched argument names and modes"
+        );
+
+        let return_table = return_set && argmodes.contains(&ProArgMode::Table);
+
+        // provide default names for any args that don't have one
+        let mut argnames = argnames
+            .into_iter()
+            .enumerate()
+            .map(|(idx, name)| name.unwrap_or_else(|| format!("arg{}", idx)))
+            .collect::<Vec<_>>();
+
+        // convert the raw type oids into `PgOid`
+        let mut argtypes = argtypes
+            .into_iter()
+            .map(|oid| PgOid::from(oid))
+            .collect::<Vec<_>>();
+
+        let mut tabletypes = Vec::new();
+        if return_table {
+            // Postgres treats the columns in a RETURNS TABLE(...) statement as arguments of type 't' (table)
+            // and we need to separate them from the rest of the arguments
+            let mut filtered_argnames = Vec::new();
+            let mut filtered_argtypes = Vec::new();
+
+            for ((argmode, argtype), argname) in argmodes
+                .into_iter()
+                .zip(argtypes.into_iter())
+                .zip(argnames.into_iter())
+            {
+                if argmode == ProArgMode::Table {
+                    // remember this 't'able argument type
+                    tabletypes.push(argtype);
+                } else {
+                    filtered_argnames.push(argname);
+                    filtered_argtypes.push(argtype);
+                }
+            }
+
+            // swap in the filtered lists of names and types
+            argnames = filtered_argnames;
+            argtypes = filtered_argtypes;
+        };
+
         let mut arguments = Vec::new();
-        for (idx, (argument_oid, maybe_arg_name)) in argument_oids_and_names.into_iter().enumerate()
-        {
+        for (type_oid, arg_name) in argtypes.into_iter().zip(argnames.into_iter()) {
             let rust_type: syn::Type = {
-                let bare = oid_to_syn_type(&argument_oid, false)?;
+                let bare = oid_to_syn_type(&type_oid, false)?;
                 match is_strict {
                     true => bare,
                     false => syn::parse2(quote! {
@@ -54,10 +111,7 @@ impl CrateVariant {
                 }
             };
 
-            let arg_name = match maybe_arg_name.as_deref() {
-                Some("") | None => Ident::new(&format!("arg{}", idx), Span::call_site()),
-                Some(argument_name) => Ident::new(&argument_name.clone(), Span::call_site()),
-            };
+            let arg_name = Ident::new(&arg_name, Span::call_site());
             let rust_pat_type: syn::FnArg = syn::parse2(quote! {
                 #arg_name: #rust_type
             })
@@ -69,12 +123,29 @@ impl CrateVariant {
         let return_type: syn::Type = {
             let bare = oid_to_syn_type(&return_oid, true)?;
             match return_set {
-                true => syn::parse2(quote! { ::std::result::Result<Option<::pgx::iter::SetOfIterator<'a, Option<#bare>>>, Box<dyn ::std::error::Error>> })
-                    .wrap_err("Wrapping return type")?,
-                false => syn::parse2(
-                    quote! { ::std::result::Result<Option<#bare>, Box<dyn ::std::error::Error>> },
-                )
-                .wrap_err("Wrapping return type")?,
+                true => match return_table {
+                    true => {
+                        // it's a `RETURNS TABLE(...)`
+                        let syntypes = tabletypes
+                            .into_iter()
+                            .map(|t| oid_to_syn_type(&t, true))
+                            .collect::<Result<Vec<_>, _>>()?;
+                        syn::parse2(quote! {
+                            ::std::result::Result::<Option<::pgx::iter::TableIterator<'a, ( #(Option<#syntypes>),*, ) >>, Box<dyn ::std::error::Error>>
+                        }).wrap_err("Wrapping TableIterator return type")?
+                    }
+
+                    false => {
+                        // it's a `RETURNS SETOF xxx`
+                        syn::parse2(quote! { ::std::result::Result<Option<::pgx::iter::SetOfIterator<'a, Option<#bare>>>, Box<dyn ::std::error::Error>> })
+                            .wrap_err("Wrapping SetOfIterator return type")?
+                    }
+                },
+
+                false => {
+                    // it's a plain `RETURNS xxx`
+                    syn::parse2(quote! { ::std::result::Result<Option<#bare>, Box<dyn ::std::error::Error>> }).wrap_err("Wrapping return type")?
+                }
             }
         };
 

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -401,6 +401,7 @@ fn check_dependencies_against_allowed(dependencies: &toml::value::Table) -> eyre
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {
+    use crate::pgproc::ProArgMode;
     use pgx::*;
     use quote::quote;
     use syn::parse_quote;
@@ -417,12 +418,15 @@ mod tests {
             let target_dir = crate::gucs::work_dir();
 
             let variant = {
-                let argument_oids_and_names =
-                    vec![(PgOid::from(PgBuiltInOids::TEXTOID.value()), None)];
+                let argnames = vec![None];
+                let argtypes = vec![pg_sys::TEXTOID];
+                let argmodes = vec![ProArgMode::In];
                 let return_oid = PgOid::from(PgBuiltInOids::TEXTOID.value());
                 let is_strict = true;
                 let return_set = false;
-                CrateVariant::function(argument_oids_and_names, return_oid, return_set, is_strict)?
+                CrateVariant::function(
+                    argnames, argtypes, argmodes, return_oid, return_set, is_strict,
+                )?
             };
             let user_deps = toml::value::Table::default();
             let user_code = syn::parse2(quote! {


### PR DESCRIPTION
This work was on accident and not done yet.  It'll also require pgx to be fixed such that it knows how to return a `Result<Option<TableIterator<'a, (..., ..., ...)>>, E>`, which is looking to be really freakin' difficult work.