### PR TITLE
address issue #197 by blocking RETURNS TABLE, OUT and INOUT function argument

### DIFF
--- a/plrust/src/pgproc.rs
+++ b/plrust/src/pgproc.rs
@@ -126,6 +126,11 @@ impl PgProc {
             .unwrap_or_default()
     }
 
+    pub(crate) fn proargmodes(&self) -> Vec<i8> {
+        self.get_attr(pg_sys::Anum_pg_proc_proargmodes)
+            .unwrap_or_default()
+    }
+
     pub(crate) fn prorettype(&self) -> pg_sys::Oid {
         // SAFETY:  `prorettype` has a NOT NULL constraint
         self.get_attr(pg_sys::Anum_pg_proc_prorettype).unwrap()

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -70,6 +70,16 @@ impl FnCrating {
                 let argnames = meta.proargnames();
                 let argtypes = meta.proargtypes();
 
+                // quick fix for issue #197 (and likely related problems) -- we don't yet support these things
+                let argmodes = meta.proargmodes();
+                if argmodes.contains(&('t' as i8)) {
+                    todo!("RETURNS TABLE functions")
+                } else if argmodes.contains(&('o' as i8)) {
+                    todo!("OUT arguments")
+                } else if argmodes.contains(&('b' as i8)) {
+                    todo!("INOUT arguments")
+                }
+
                 // we must have the same number of argument names and argument types.  It's seemingly
                 // impossible that we never would, but lets make sure as it's an invariant from this
                 // point forward


### PR DESCRIPTION
We don't support these things yet, and this improves the error message from

```
ERROR:  assertion failed: `(left == right)`
  left: `1`,
 right: `0`
```

to

```
ERROR:  not yet implemented: OUT arguments   # (or `RETURNS TABLE functions` or `INOUT arguments`)
```