### PR TITLE
Remove pointless build.rs from plrustc

### DIFF
--- a/plrustc/plrustc/build.rs
+++ b/plrustc/plrustc/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!(
-        "cargo:rustc-env=PROFILE={}",
-        std::env::var("PROFILE").unwrap_or_default(),
-    );
-    // rustc_tools_util::setup_version_info!();
-}


### PR DESCRIPTION
This was not needed after the overhaul. It's harmless, but makes builds very slightly slower (plrustc already builds so fast that it basically doesn't matter at all).

We should wait for #238 before landing this, since that adds plrustc CI. This does not need to be in the next release.