### PR TITLE
Add `./build.sh install` as a method of installing `plrustc` (uses `cargo install` to perform the installation)

### DIFF
--- a/plrustc/build.sh
+++ b/plrustc/build.sh
@@ -64,15 +64,25 @@ fi
 
 echo "plrustc build starting..." >&2
 
-env RUSTFLAGS="$RUSTFLAGS" \
-     "$CARGO" build --release \
-        -p plrustc --bin plrustc \
-        --target "$host"
 
-cd "$repo_root"
+if [[ "$1" = "install" ]]; then
+    env RUSTFLAGS="$RUSTFLAGS" \
+        "$CARGO" install \
+            --path . \
+            --target "$host"
 
-mkdir -p "$repo_root/build/bin"
-cp "$CARGO_TARGET_DIR/$host/release/plrustc" "$repo_root/build/bin/plrustc"
+    echo "plrustc installation (with 'cargo install') completed" >&2
+else
+    env RUSTFLAGS="$RUSTFLAGS" \
+        "$CARGO" build --release \
+            -p plrustc --bin plrustc \
+            --target "$host"
 
-echo "plrustc build completed" >&2
-echo "  result binary is located at '$repo_root/build/bin/plrustc'" >&2
+    cd "$repo_root"
+
+    mkdir -p "$repo_root/build/bin"
+    cp "$CARGO_TARGET_DIR/$host/release/plrustc" "$repo_root/build/bin/plrustc"
+
+    echo "plrustc build completed" >&2
+    echo "  result binary is located at '$repo_root/build/bin/plrustc'" >&2
+fi


### PR DESCRIPTION
As described. If no args are given (or the arg isn't literally `install`), the current way is used.

It's likely some additional sophistication for this script wouldn't be amiss, but for now this seems fine.