### PR TITLE
Remove `RUSTC_WRAPPER` from the env if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ process.  We recommend Postgres' execution environment be properly sanitized to 
 
 As a pre-emptive measure, PL/Rust proactively unsets a few environment variables that could negatively impact user function
 compilation:  
- `DOCS_RS, PGX_BUILD_VERBOSE, PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE, CARGO_MANIFEST_DIR, OUT_DIR`
+ `DOCS_RS, PGX_BUILD_VERBOSE, PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE, CARGO_MANIFEST_DIR, OUT_DIR, RUSTC_WRAPPER, RUSTC_WORKSPACE_WRAPPER`
 (These are generally things used by the `pgx` development team and not at all necessary for PL/Rust.)
 
 `plrustc` also performs a search for the location of the Rust sysroot which is informed by several environment variables (specifically `PLRUSTC_SYSROOT`, `SYSROOT`, `RUSTUP_TOOLCHAIN`, and `RUSTUP_HOME`). The details of how this search is performed are documented in the ([`plrustc` README](./plrustc/README.md)), but it is very similar to the search performed by `clippy`, `miri`, and other tools that use the `rustc_driver` library.

--- a/plrust/src/user_crate/cargo.rs
+++ b/plrust/src/user_crate/cargo.rs
@@ -120,6 +120,7 @@ fn sanitize_env(command: &mut Command) {
     command.env_remove("CARGO_MANIFEST_DIR"); // we are in the manifest directory b/c of `command.current_dir()` above
     command.env_remove("OUT_DIR"); // rust's default decision for OUT_DIR is perfectly acceptable to PL/Rust
     command.env_remove("RUSTC_WRAPPER"); // plrustc doesn't like being invoked with RUSTC_WRAPPER set.
+    command.env_remove("RUSTC_WORKSPACE_WRAPPER"); // ditto.
 }
 
 /// Asks Postgres, via FFI, for all of its compile-time configuration data.  This is the full

--- a/plrust/src/user_crate/cargo.rs
+++ b/plrust/src/user_crate/cargo.rs
@@ -119,6 +119,7 @@ fn sanitize_env(command: &mut Command) {
     command.env_remove("PGX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE"); // while an interesting idea, PL/Rust user functions are not used to generate a `pgx` release
     command.env_remove("CARGO_MANIFEST_DIR"); // we are in the manifest directory b/c of `command.current_dir()` above
     command.env_remove("OUT_DIR"); // rust's default decision for OUT_DIR is perfectly acceptable to PL/Rust
+    command.env_remove("RUSTC_WRAPPER"); // plrustc doesn't like being invoked with RUSTC_WRAPPER set.
 }
 
 /// Asks Postgres, via FFI, for all of its compile-time configuration data.  This is the full


### PR DESCRIPTION
Meant to do this a while ago. This may or may not clear up the issues we had with sccache (no idea), but we shouldn't inherit this from the user env.