### PR TITLE
take a look at using `#![no_std]` for user functions.

### DIFF
--- a/plrust/src/user_crate/crate_variant.rs
+++ b/plrust/src/user_crate/crate_variant.rs
@@ -69,10 +69,10 @@ impl CrateVariant {
         let return_type: syn::Type = {
             let bare = oid_to_syn_type(&return_oid, true)?;
             match return_set {
-                true => syn::parse2(quote! { ::std::result::Result<Option<::pgx::iter::SetOfIterator<'a, Option<#bare>>>, Box<dyn std::error::Error + Send + Sync + 'static>> })
+                true => syn::parse2(quote! { ::core::result::Result<Option<::pgx::iter::SetOfIterator<'a, Option<#bare>>>, crate::PlRustFunctionError> })
                     .wrap_err("Wrapping return type")?,
                 false => syn::parse2(
-                    quote! { ::std::result::Result<Option<#bare>, Box<dyn std::error::Error + Send + Sync + 'static>> },
+                    quote! { ::core::result::Result<Option<#bare>, crate::PlRustFunctionError> },
                 )
                 .wrap_err("Wrapping return type")?,
             }


### PR DESCRIPTION
In terms of getting `#![no_std]` tied in, this pretty much does it.

I dunno if there's more we should look at regarding error handling.  What little bit is here (the `PlRustFunctionError`) type seems to do the needful and none of the existing tests needed to be updated to account for it, which was my primary goal.