### PR TITLE
Avoid linking to `rust-lang/rust`'s issue tracker if `plrustc` panics

### DIFF
--- a/plrustc/plrustc/uitests/ice_hook.rs
+++ b/plrustc/plrustc/uitests/ice_hook.rs
@@ -1,0 +1,11 @@
+// rustc-env:RUST_BACKTRACE=0
+// rustc-env:PLRUSTC_INCLUDE_TEST_ONLY_LINTS=1
+// normalize-stderr-test: "plrustc version: .*" -> "plrustc version: <version here>"
+// normalize-stderr-test: "lints.rs:\d*:\d*" -> "lints.rs"
+// normalize-stderr-test: "(?ms)query stack during panic:\n.*end of query stack\n" -> ""
+#![crate_type = "lib"]
+// The comments above are to clean up file/line/version numbers, backtrace info,
+// etc. We want to avoid ice_hook.stderr changing more than is needed.
+
+// This function name is special-cased in `PlrustcForceIce`
+pub fn plrustc_would_like_some_ice() {}

--- a/plrustc/plrustc/uitests/ice_hook.stderr
+++ b/plrustc/plrustc/uitests/ice_hook.stderr
@@ -1,0 +1,11 @@
+thread 'rustc' panicked at 'Here is your ICE', plrustc/src/lints.rs
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+error: internal compiler error: unexpected panic
+
+note: `plrustc` unexpectedly panicked. This is probably a bug.
+
+note: Please file a bug report at <https://github.com/tcdi/plrust/issues/new>
+
+note: plrustc version: <version here>
+


### PR DESCRIPTION
I wrote some buggy code and noticed we tell the user to file a bug against `rust-lang/rust`. That seems bad since it will probably annoy people upstream if they have to field plrustc issues.

Most of the complexity here is:

1. Allowing this to be mor tested.
2. Setting up the code needed to report a one-shot error from a location that doesn't have access to the error reporting machinery.

The second of these is the more confusing bit, but it's also something we will want anyway in the long term (at which point I'll factor it out).