### PR TITLE
Correctly expand args given to plrustc

### DIFF
--- a/plrustc/plrustc/src/main.rs
+++ b/plrustc/plrustc/src/main.rs
@@ -51,6 +51,7 @@ fn main() {
     rustc_driver::init_rustc_env_logger();
     std::process::exit(rustc_driver::catch_with_exit_code(move || {
         let orig_args: Vec<String> = std::env::args().collect();
+        let orig_args = rustc_driver::args::arg_expand_all(&orig_args);
 
         let sysroot_arg = arg_value(&orig_args, "--sysroot");
         let have_sysroot_arg = sysroot_arg.is_some();


### PR DESCRIPTION
Cargo will sometimes spill args to a separate file if they're too long, passing them as `@path/to/argfile`, so we should ensure they're expanded. Thankfully, there's an easy to use function in rustc_driver for this.