### PR TITLE
Fix issue #255

### DIFF
--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -1142,6 +1142,29 @@ mod tests {
         assert_eq!("operation not supported on this platform", &string);
         Ok(())
     }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic(expected = "PL/Rust does not support unnamed arguments")]
+    fn unnamed_args() -> spi::Result<()> {
+        Spi::run("CREATE FUNCTION unnamed_arg(int) RETURNS int LANGUAGE plrust as $$ Ok(None) $$;")
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic(expected = "PL/Rust does not support unnamed arguments")]
+    fn named_unnamed_args() -> spi::Result<()> {
+        Spi::run("CREATE FUNCTION named_unnamed_arg(bob text, int) RETURNS int LANGUAGE plrust as $$ Ok(None) $$;")
+    }
+
+    #[pg_test]
+    #[search_path(@extschema@)]
+    #[should_panic(
+        expected = "is an invalid Rust identifier and cannot be used as an argument name"
+    )]
+    fn invalid_arg_identifier() -> spi::Result<()> {
+        Spi::run("CREATE FUNCTION invalid_arg_identifier(\"this isn't a valid rust identifier\" int) RETURNS int LANGUAGE plrust as $$ Ok(None) $$;")
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -355,8 +355,10 @@ mod tests {
             let db_oid = unsafe { pg_sys::MyDatabaseId };
 
             let variant = {
-                let argument_oids_and_names =
-                    vec![(PgOid::from(PgBuiltInOids::TEXTOID.value()), None)];
+                let argument_oids_and_names = vec![(
+                    PgOid::from(PgBuiltInOids::TEXTOID.value()),
+                    syn::parse_str("arg0")?,
+                )];
                 let return_oid = PgOid::from(PgBuiltInOids::TEXTOID.value());
                 let is_strict = true;
                 let return_set = false;
@@ -426,7 +428,7 @@ mod tests {
             let variant = {
                 let argument_oids_and_names = vec![(
                     PgOid::from(PgBuiltInOids::INT4OID.value()),
-                    Some("val".into()),
+                    syn::parse_str("val")?,
                 )];
                 let return_oid = PgOid::from(PgBuiltInOids::INT8OID.value());
                 let is_strict = false;
@@ -497,7 +499,7 @@ mod tests {
             let variant = {
                 let argument_oids_and_names = vec![(
                     PgOid::from(PgBuiltInOids::TEXTOID.value()),
-                    Some("val".into()),
+                    syn::parse_str("val")?,
                 )];
                 let return_oid = PgOid::from(PgBuiltInOids::TEXTOID.value());
                 let is_strict = true;

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -431,8 +431,10 @@ mod tests {
             let target_dir = crate::gucs::work_dir();
 
             let variant = {
-                let argument_oids_and_names =
-                    vec![(PgOid::from(PgBuiltInOids::TEXTOID.value()), None)];
+                let argument_oids_and_names = vec![(
+                    PgOid::from(PgBuiltInOids::TEXTOID.value()),
+                    syn::parse_str("arg0")?,
+                )];
                 let return_oid = PgOid::from(PgBuiltInOids::TEXTOID.value());
                 let is_strict = true;
                 let return_set = false;


### PR DESCRIPTION
PL/Rust does not support unnamed function arguments.  And more generally, PL/Rust does not support function argument names that aren't also valid Rust identifiers.

This catches all of these situations and raises the appropriate SQL error.