### PR TITLE
Document #255

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -21,6 +21,8 @@
     - [Lints](./config-lints.md)
     - [Environment variables](./config-env-var.md)
 - [Trusted and Untrusted PL/Rust](./trusted-untrusted.md)
+- [Rules and Regulations](./rules-regulations.md)
+
 
 # PL/Rust Under the Hood
 

--- a/doc/src/rules-regulations.md
+++ b/doc/src/rules-regulations.md
@@ -1,0 +1,65 @@
+# Rules and Regulations
+
+This page outlines guidelines for using PL/Rust.
+
+
+## Argument names
+
+PL/Rust functions with arguments require named arguments.
+This is different from functions written in
+[other languages](https://www.postgresql.org/docs/current/sql-createfunction.html),
+such as SQL where `strlen(TEXT, INT)` allows the use of
+`$1` and `$2` within the function body.
+
+
+
+
+The succinct reason anonymous parameters are not allowed is because
+"It does not align with Rust."  Requiring named parameters
+keeps functionality simple, direct and obvious.
+
+One of the reasons people use Rust is because of the quality of the compiler's feedback on incorrect code. Allowing anonymous parameters would ultimately require transforming the code in a way that would either result in potentially garbled error messages, or arbitrarily restricting what sets of identifiers can be used. Simply requiring identifiers skips all of that.
+
+```sql
+CREATE FUNCTION plrust.strlen(TEXT)
+    RETURNS BIGINT
+    LANGUAGE plrust STRICT
+AS $$
+    Ok(Some(arg0.len() as i64))
+$$;
+```
+
+
+```
+ERROR:  PL/Rust does not support unnamed arguments
+DETAIL:  PL/Rust argument names must also be valid Rust identifiers.  Rust's identifier specification can be found at https://doc.rust-lang.org/reference/identifiers.html
+```
+
+
+As the above error's detail explains, PL/Rust argument names
+must be
+[valid Rust identifiers](https://doc.rust-lang.org/reference/identifiers.html).
+
+
+```sql
+CREATE FUNCTION plrust.strlen("this name is not supported" TEXT)
+    RETURNS BIGINT
+    LANGUAGE plrust STRICT
+AS $$
+    Ok(Some("this name is not supported".len() as i64))
+$$;
+```
+
+
+## Argument Types
+
+
+`Option<T>` or `T` depending on `STRICT`
+
+
+## Return types
+
+`Result<Option<T>>`
+
+
+

--- a/doc/src/update-plrust.md
+++ b/doc/src/update-plrust.md
@@ -24,23 +24,32 @@ sudo chown postgres -R /usr/lib/postgresql/15/lib/
 sudo su - postgres
 cd ~/plrust
 git pull
-cargo install cargo-pgx --version 0.7.2 --locked
-
-cd ~/plrust/plrust
-
-exit
+cargo install cargo-pgx --locked
 ```
-
 
 
 ## Update PL/Rust
 
 
-Follow these steps to upgrade PL/Rust from GitLab to test
-the latest release.  
+Follow these steps to upgrade PL/Rust from GitLab to use
+the latest release.
+
+
+Update `plrustc`, `postgrestd` and `plrust` installations.
 
 ```bash
-cargo pgx install --release -c /usr/bin/pg_config
+cd ~/plrust/plrustc
+./build.sh
+mv ~/plrust/build/bin/plrustc ~/.cargo/bin/
+
+cd ~/plrust/plrust
+PG_VER=15 \
+    STD_TARGETS="x86_64-postgres-linux-gnu " \
+    ./build
+
+cargo pgx install --release \
+    --features trusted \
+    -c /usr/bin/pg_config
 ```
 
 


### PR DESCRIPTION
Should finish #255.  Updates details about function argument names being required, etc.  Moved to new rules and regs section and made notes of additional examples to document.

Improves plrust update notes. Everything needs updating when installing PL/Rust updates.