### PR TITLE
Adds workflow_dispatch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
This should provide us with the ability to kick off a build whenever, similar to PGX. The ability will only show up once this gets into `main` however