### PR TITLE
fail to create on databases that aren't `UTF8`

### DIFF
--- a/doc/src/install-plrust.md
+++ b/doc/src/install-plrust.md
@@ -200,9 +200,11 @@ sudo chown root -R /usr/lib/postgresql/15/lib/
 Create a `plrust` database and connect to the `plrust` database
 using `psql`.
 
+PL/Rust only supports databases encoded as `UTF8`.  This is to ensure proper compatibility between Postgres/SQL `TEXT`
+(and internal strings) and Rust `String` and `&str` types.
 
 ```bash
-sudo -u postgres psql -c "CREATE DATABASE plrust;"
+sudo -u postgres psql -c "CREATE DATABASE plrust WITH ENCODING = 'utf8' TEMPLATE = 'template0';"
 sudo -u postgres psql -d plrust
 ```
 

--- a/doc/src/install-prerequisites.md
+++ b/doc/src/install-prerequisites.md
@@ -21,9 +21,14 @@ Steps to install PL/Rust:
 
 PL/Rust requires PostgreSQL and all prerequisites outlined for
 [pgx](https://github.com/tcdi/pgx#system-requirements)
-are installed.
-Pay special attention to
-[PostgreSQL's build dependencies](https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code).
+are installed.  
+
+PL/Rust also requires that any databases in which it's created is `UTF8`.  Postgres' default encoding is determined
+by the locale of the environment when `initdb` is first run.  Depending on your operating system configuration, this may 
+not resolve to `UTF8`.
+
+[Building PL/Rust from source](https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code) requires 
+installing `cargo-pgx` which requires a development toolchain capable of building Postgres itself.
 
 
 ### Permissions

--- a/doc/src/rules-regulations.md
+++ b/doc/src/rules-regulations.md
@@ -2,6 +2,14 @@
 
 This page outlines guidelines for using PL/Rust.
 
+## Database Encoding
+
+PL/Rust only supports databases encoded as `UTF8`.  This is something that must be specified either at `initdb`-time or
+during `CREATE DATABASE`.
+
+The reason for this is Rust strictly only supports UTF8-encoding Strings, and requiring this of the database not only
+ensures there's no undefined behavior around String conversions, it allows PL/Rust to do certain `TEXT`->`&str` Datum
+conversions as zero-copy operations.
 
 ## Argument names
 

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -51,7 +51,22 @@ use pgx::{pg_getarg, prelude::*};
 
 #[cfg(any(test, feature = "pg_test"))]
 pub use tests::pg_test;
+
 pgx::pg_module_magic!();
+
+extension_sql!(
+    r#"
+DO LANGUAGE plpgsql $$
+BEGIN
+   IF pg_catalog.getdatabaseencoding() <> 'UTF8' THEN
+        RAISE EXCEPTION 'PL/Rust only supports UTF8-encoded databases.';
+   END IF;
+END;
+$$;
+"#,
+    name = "check_encoding",
+    bootstrap
+);
 
 /// This is the default set of lints we apply to PL/Rust user functions, and require of PL/Rust user
 /// functions before we'll load and execute them.


### PR DESCRIPTION
PL/Rust can't support databases that aren't UTF8 because of Rust's requirements around Strings being proper UTF8.  This PR causes `CREATE EXTENSION plrust` to raise an ERROR in this case:

```sql
[v14.6][2495941] plrust=# create extension plrust;
ERROR:  PL/Rust only supports UTF8-encoded databases
```

This might be a little heavy-handed now but it gives us time to consider other options for relaxing this requirement.

The decision here stems from the fact that, currently, `pgx` blindly assumes all `TEXT` Datum conversions are valid UTF8, when they might not be.  That's a problem too, but it's still not clear the RightWay to resolve that and likely wouldn't do us any good here in plrust anyways.