### PR TITLE
Update create function examples to include REPLACE for easy copy/paste.

### DIFF
--- a/doc/src/install-plrust.md
+++ b/doc/src/install-plrust.md
@@ -228,7 +228,7 @@ that simply returns the integer 1.
 
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT LANGUAGE plrust
 AS
 $$

--- a/doc/src/logging.md
+++ b/doc/src/logging.md
@@ -19,7 +19,7 @@ PostgreSQL logs defined by your `postgresql.conf`.  Running the following
 example of `plrust.one()` creates a `LOG` record.
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT
     LANGUAGE plrust
 AS
@@ -56,7 +56,7 @@ in the logged message string.
 
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT
     LANGUAGE plrust
 AS
@@ -84,7 +84,7 @@ Warnings are sent to the log file as well as being returned to the client as a
 
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT
     LANGUAGE plrust
 AS
@@ -133,7 +133,7 @@ to an `error`.
 
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT
     LANGUAGE plrust
 AS
@@ -183,7 +183,7 @@ the query.  These options do not log the message to the PostgreSQL logs.
 
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT
     LANGUAGE plrust
 AS

--- a/doc/src/rules-regulations.md
+++ b/doc/src/rules-regulations.md
@@ -29,7 +29,7 @@ keeps functionality simple, direct and obvious.
 One of the reasons people use Rust is because of the quality of the compiler's feedback on incorrect code. Allowing anonymous parameters would ultimately require transforming the code in a way that would either result in potentially garbled error messages, or arbitrarily restricting what sets of identifiers can be used. Simply requiring identifiers skips all of that.
 
 ```sql
-CREATE FUNCTION plrust.strlen(TEXT)
+CREATE OR REPLACE FUNCTION plrust.strlen(TEXT)
     RETURNS BIGINT
     LANGUAGE plrust STRICT
 AS $$
@@ -50,7 +50,7 @@ must be
 
 
 ```sql
-CREATE FUNCTION plrust.strlen("this name is not supported" TEXT)
+CREATE OR REPLACE FUNCTION plrust.strlen("this name is not supported" TEXT)
     RETURNS BIGINT
     LANGUAGE plrust STRICT
 AS $$

--- a/doc/src/triggers.md
+++ b/doc/src/triggers.md
@@ -44,7 +44,7 @@ This code is explained further after the code block.
 
 
 ```sql
-CREATE FUNCTION plrust.dog_trigger()
+CREATE OR REPLACE FUNCTION plrust.dog_trigger()
 RETURNS trigger AS
 $$
     let tg_op = trigger.op()?;

--- a/doc/src/use-plrust.md
+++ b/doc/src/use-plrust.md
@@ -42,7 +42,7 @@ The following example creates a basic `plrust` function named
 
 
 ```sql
-CREATE FUNCTION plrust.one()
+CREATE OR REPLACE FUNCTION plrust.one()
     RETURNS INT
     LANGUAGE plrust
 AS
@@ -61,7 +61,7 @@ defined in the function definition can be used directly in the Rust
 code within the function's body.
 
 ```sql
-CREATE FUNCTION plrust.strlen(val TEXT)
+CREATE OR REPLACE FUNCTION plrust.strlen(val TEXT)
     RETURNS BIGINT
     LANGUAGE plrust
 AS $$
@@ -91,7 +91,7 @@ of `plrust.strlen` works the same as above.
 
 
 ```sql
-    CREATE FUNCTION plrust.strlen(val TEXT)
+    CREATE OR REPLACE FUNCTION plrust.strlen(val TEXT)
     RETURNS BIGINT
     LANGUAGE plrust STRICT
 AS $$
@@ -123,7 +123,7 @@ PL/Rust functions can performance calculations, such as converting
 distance values from feet to miles.
 
 ```sql
-CREATE FUNCTION plrust.distance_feet_to_miles(feet FLOAT)
+CREATE OR REPLACE FUNCTION plrust.distance_feet_to_miles(feet FLOAT)
     RETURNS FLOAT
     LANGUAGE plrust STRICT
 AS $$
@@ -158,7 +158,7 @@ The `random_first_name()` function returns a random first name using the
  
 
 ```sql
-CREATE FUNCTION plrust.random_slogan() RETURNS TEXT
+CREATE OR REPLACE FUNCTION plrust.random_slogan() RETURNS TEXT
 LANGUAGE plrust AS $$
 [dependencies]
     faker_rand = "0.1"
@@ -184,7 +184,7 @@ SELECT plrust.random_slogan();
 
 
 ```sql
-CREATE FUNCTION plrust.random_company_name(locale TEXT)
+CREATE OR REPLACE FUNCTION plrust.random_company_name(locale TEXT)
     RETURNS TEXT
     LANGUAGE plrust STRICT
 AS $$


### PR DESCRIPTION
This is a very simple update to modify the example create function SQL statements to use CREATE OR REPLACE in order to make copy/paste more simple since many examples share the same function schema and name combination.
