### PR TITLE
Adds Dockerfile for quick trial use of plrust

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.DS_Store
+.idea/
+target/
+*.iml
+**/*.rs.bk
+*.o
+*.so
+*.a
+cmake*/
+.direnv
+plrust/postgrestd
+.git
+Dockerfile.try

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
       run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 
     - name: Run cargo pgx init for PG14
-      run: cargo pgx init --pg14 $(which pg_config)
+      run: cargo pgx init --pg$PG_VER $(which pg_config)
 
     - name: Test PL/rust as "untrusted"
       if: matrix.target == 'host'
@@ -155,7 +155,7 @@ jobs:
 
     - name: Test PL/rust as "trusted" (inc. postgrestd)
       if: matrix.target == 'postgrestd'
-      run: cd plrust && STD_TARGETS="aarch64-postgres-linux-gnu" ./build
+      run: cd plrust && STD_TARGETS="aarch64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
 
     - name: Print sccache stats (after build)
       run: sccache --show-stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     - name: install plrustc
       run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 
-    - name: Run cargo pgx init for PG14
+    - name: Run cargo pgx init
       run: cargo pgx init --pg$PG_VER $(which pg_config)
 
     - name: Test PL/rust as "untrusted"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
 
     - name: Test PL/rust as "trusted" (inc. postgrestd)
       if: matrix.target == 'postgrestd'
-      run: cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build
+      run: cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
 
     # # Maybe this is not necessary if we switch to sccache?
     # # Attempt to make the cache payload slightly smaller.

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -53,7 +53,7 @@ RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 RUN cargo pgx init --pg15 $(which pg_config)
 
 # Build and install plrust as trusted
-RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --features trusted
+RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --release --features trusted
 
 # Reset the permissions of files/directories that was created or touched by the postgres user
 # Switching to the root user here temporarily is easier than installing and setting up sudo

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -71,10 +71,8 @@ USER postgres
 RUN pg_createcluster 15 main
 
 # Set up host based auth. *DO NOT* use this in production!
-RUN cat <<EOF > /etc/postgresql/15/main/pg_hba.conf
-local all all trust
-host all all 0.0.0.0/0 trust
-EOF
+RUN echo 'local all all trust' > /etc/postgresql/15/main/pg_hba.conf && \
+    echo 'host all all 0.0.0.0/0 trust' >> /etc/postgresql/15/main/pg_hba.conf
 
 # Set up plrust configuration options
 RUN echo "shared_preload_libraries='plrust'" >> /etc/postgresql/15/main/postgresql.conf && \

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -70,6 +70,12 @@ USER postgres
 # Create initial main database
 RUN pg_createcluster 15 main
 
+# Set up host based auth. *DO NOT* use this in production!
+RUN cat <<EOF > /etc/postgresql/15/main/pg_hba.conf
+local all all trust
+host all all 0.0.0.0/0 trust
+EOF
+
 # Set up plrust configuration options
 RUN cat <<EOF >> /etc/postgresql/15/main/postgresql.conf
 shared_preload_libraries='plrust'

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -55,6 +55,20 @@ RUN cargo pgx init --pg15 $(which pg_config)
 # Build and install plrust as trusted
 RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --features trusted
 
+# Reset the permissions of files/directories that was created or touched by the postgres user
+# Switching to the root user here temporarily is easier than installing and setting up sudo
+USER root
+
+RUN chmod 0755 `$(which pg_config) --pkglibdir` && \
+    cd `$(which pg_config) --pkglibdir` && \
+    chown root:root *.so && \
+    chmod 0644 *.so && \
+    chmod 755 `$(which pg_config) --sharedir`/extension && \
+    cd `$(which pg_config) --sharedir`/extension && \
+    chown root:root *
+
+USER postgres
+
 # Create initial main database
 RUN pg_createcluster 15 main
 

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -53,8 +53,7 @@ RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 RUN cargo pgx init --pg15 $(which pg_config)
 
 # Build and install plrust as trusted
-# cargo pgx install --features trusted???
-RUN cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo pgx install --features trusted
+RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --features trusted
 
 # Create initial main database
 RUN pg_createcluster 15 main

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -2,6 +2,8 @@ FROM postgres:15-bullseye
 
 SHELL ["/bin/bash", "-c"]
 
+# Install just enough to set up the official Postgres debian repository,
+# then install everything else we need for Rust and plrust
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -40,21 +42,7 @@ ENV PATH="/var/lib/postgresql/.cargo/bin:${PATH}"
 COPY --chown=${USER} . src/
 WORKDIR /src
 
-# # Install exact cargo-pgx that is definied in Cargo.toml
-# RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && cargo install cargo-pgx --force --version "$TARGET_VERSION"
-
-# # Install llvm-tools-preview
-# RUN rustup component add llvm-tools-preview rustc-dev
-
-# # Build and install plrustc
-# RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin && find . -type d -name target | xargs rm -r
-
-# # Init cargo pgx against installed postgres version
-# RUN cargo pgx init --pg15 $(which pg_config)
-
-# # Build and install plrust as trusted
-# RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --release --features trusted && find . -type d -name target | xargs rm -r
-
+# Build/install/remove all that is necessary in one step as to keep the resulting layer as small as possible.
 RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && \
     cargo install cargo-pgx --force --version "$TARGET_VERSION" && \
     rustup component add llvm-tools-preview rustc-dev && \
@@ -65,7 +53,7 @@ RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|sele
     cd /src && find . -type d -name target | xargs rm -r && \
     rustup component remove llvm-tools-preview rustc-dev
 
-# Reset the permissions of files/directories that was created or touched by the postgres user
+# Reset the permissions of files/directories that was created or touched by the postgres user.
 # Switching to the root user here temporarily is easier than installing and setting up sudo
 USER root
 
@@ -94,6 +82,7 @@ RUN cat <<EOT >> ~/.psqlrc
 \set PROMPT2 '%/(plrust)-# '
 EOT
 
+# Create startup/CMD scripts
 RUN mkdir ~/scripts
 ENV PATH="~/scripts:${PATH}"
 
@@ -130,4 +119,6 @@ EOT
 
 RUN chmod +x ~/scripts/server
 
+# By default, we will run the "all" script, which will start up the postgres server in the background,
+# and the psql cli in the foreground
 CMD [ "all" ]

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -43,8 +43,8 @@ COPY --chown=${USER} . src/
 WORKDIR /src
 
 # Build/install/remove all that is necessary in one step as to keep the resulting layer as small as possible.
-RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && \
-    cargo install cargo-pgx --force --version "$TARGET_VERSION" && \
+RUN PGX_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && \
+    cargo install cargo-pgx --force --version "$PGX_VERSION" && \
     rustup component add llvm-tools-preview rustc-dev && \
     cd /src/plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin && \
     cargo pgx init --pg15 $(which pg_config) && \
@@ -71,23 +71,23 @@ USER postgres
 RUN pg_createcluster 15 main
 
 # Set up plrust configuration options
-RUN cat <<EOT >> /etc/postgresql/15/main/postgresql.conf
+RUN cat <<EOF >> /etc/postgresql/15/main/postgresql.conf
 shared_preload_libraries='plrust'
 plrust.work_dir='/tmp'
-EOT
+EOF
 
 # Set up custom prompt
-RUN cat <<EOT >> ~/.psqlrc
+RUN cat <<EOF >> ~/.psqlrc
 \set PROMPT1 '%/(plrust)=# '
 \set PROMPT2 '%/(plrust)-# '
-EOT
+EOF
 
 # Create startup/CMD scripts
 RUN mkdir ~/scripts
 ENV PATH="~/scripts:${PATH}"
 
 # Set up script that launches both postgresql server (background) and psql client (foreground)
-RUN cat <<EOT >> ~/scripts/all
+RUN cat <<EOF >> ~/scripts/all
 echo "Starting Postgresql..."
 service postgresql start
 echo ""
@@ -97,13 +97,13 @@ echo ""
 echo "Starting psql"
 echo ""
 psql
-EOT
+EOF
 
 RUN chmod +x ~/scripts/all
 
 # Set up script that launches Postgresql in the foreground. Need to launch it as a service first so that
 # plrust can be installed.
-RUN cat <<EOT >> ~/scripts/server
+RUN cat <<EOF >> ~/scripts/server
 echo "Starting Postgresql service..."
 service postgresql start
 echo ""
@@ -115,7 +115,7 @@ service postgresql stop
 echo "Starting Postgresql in the foreground"
 echo ""
 postgres -D /etc/postgresql/15/main/
-EOT
+EOF
 
 RUN chmod +x ~/scripts/server
 

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -47,13 +47,13 @@ RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|sele
 RUN rustup component add llvm-tools-preview rustc-dev
 
 # Build and install plrustc
-RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
+RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin && find . -type d -name target | xargs rm -r
 
 # Init cargo pgx against installed postgres version
 RUN cargo pgx init --pg15 $(which pg_config)
 
 # Build and install plrust as trusted
-RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --release --features trusted
+RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --release --features trusted &&  find . -type d -name target | xargs rm -r
 
 # Reset the permissions of files/directories that was created or touched by the postgres user
 # Switching to the root user here temporarily is easier than installing and setting up sudo

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -1,9 +1,13 @@
+# Example of how to build and run this Dockerfile:
+#   docker build -f Dockerfile.try -t tcdi/try-plrust . # Build the container
+#   docker run -it tcdi/try-plrust # Run the container
+
 FROM postgres:15-bullseye
 
 SHELL ["/bin/bash", "-c"]
 
 # Install just enough to set up the official Postgres debian repository,
-# then install everything else we need for Rust and plrust
+# then install everything else needed for Rust and plrust
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -31,6 +35,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # Set up permissions so that the postgres user can install the plrust plugin
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
 
+# The 'postgres' user is the default user that the official postgres:15-bullseye image sets up
 USER postgres
 ENV USER postgres
 
@@ -69,6 +74,9 @@ USER postgres
 
 # Create initial main database
 RUN pg_createcluster 15 main
+
+# NOTE: Heredocs do not work in older versions of Docker, so multiple 'echo' lines
+# will be used in various places in this Dockerfile.
 
 # Set up host based auth. *DO NOT* use this in production!
 RUN echo 'local all all trust' > /etc/postgresql/15/main/pg_hba.conf && \
@@ -115,6 +123,6 @@ RUN echo 'echo "Starting Postgresql service..."' >> ~/scripts/server && \
 
 RUN chmod +x ~/scripts/server
 
-# By default, we will run the "all" script, which will start up the postgres server in the background,
+# By default, run the "all" script, which will start up the postgres server in the background,
 # and the psql cli in the foreground
 CMD [ "all" ]

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -1,0 +1,110 @@
+FROM postgres:15-bullseye
+
+SHELL ["/bin/bash", "-c"]
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg \
+        lsb-release \
+        wget && \
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null && \
+    apt-get update -y -qq --fix-missing && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        clang-11 \
+        gcc \
+        git \
+        jq \
+        libssl-dev \
+        llvm-11 \
+        make \
+        postgresql-server-dev-15 \
+        pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up permissions so that the postgres user can install the plrust plugin
+RUN chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+
+USER postgres
+ENV USER postgres
+
+# Install Rust
+RUN wget -qO- https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain=1.67.1
+ENV PATH="/var/lib/postgresql/.cargo/bin:${PATH}"
+
+# Copy in plrust source
+COPY --chown=${USER} . src/
+WORKDIR /src
+
+# Install exact cargo-pgx that is definied in Cargo.toml
+RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && cargo install cargo-pgx --force --version "$TARGET_VERSION"
+
+# Install llvm-tools-preview
+RUN rustup component add llvm-tools-preview rustc-dev
+
+# Build and install plrustc
+RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
+
+# Init cargo pgx against installed postgres version
+RUN cargo pgx init --pg15 $(which pg_config)
+
+# Build and install plrust as trusted
+# cargo pgx install --features trusted???
+RUN cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo pgx install --features trusted
+
+# Create initial main database
+RUN pg_createcluster 15 main
+
+# Set up plrust configuration options
+RUN cat <<EOT >> /etc/postgresql/15/main/postgresql.conf
+shared_preload_libraries='plrust'
+plrust.work_dir='/tmp'
+EOT
+
+# Set up custom prompt
+RUN cat <<EOT >> ~/.psqlrc
+\set PROMPT1 '%/(plrust)=# '
+\set PROMPT2 '%/(plrust)-# '
+EOT
+
+RUN mkdir ~/scripts
+ENV PATH="~/scripts:${PATH}"
+
+# Set up script that launches both postgresql server (background) and psql client (foreground)
+RUN cat <<EOT >> ~/scripts/all
+echo "Starting Postgresql..."
+service postgresql start
+echo ""
+echo "Installing plrust"
+psql -c "CREATE EXTENSION IF NOT EXISTS plrust;"
+echo ""
+echo "Starting psql"
+echo ""
+psql
+EOT
+
+RUN chmod +x ~/scripts/all
+
+# Set up script that launches Postgresql in the foreground. Need to launch it as a service first so that
+# plrust can be installed.
+RUN cat <<EOT >> ~/scripts/server
+echo "Starting Postgresql service..."
+service postgresql start
+echo ""
+echo "Installing plrust"
+psql -c "CREATE EXTENSION IF NOT EXISTS plrust;"
+echo ""
+echo "Stopping service"
+service postgresql stop
+echo "Starting Postgresql in the foreground"
+echo ""
+postgres -D /etc/postgresql/15/main/
+EOT
+
+RUN chmod +x ~/scripts/server
+
+CMD [ "all" ]

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -40,20 +40,30 @@ ENV PATH="/var/lib/postgresql/.cargo/bin:${PATH}"
 COPY --chown=${USER} . src/
 WORKDIR /src
 
-# Install exact cargo-pgx that is definied in Cargo.toml
-RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && cargo install cargo-pgx --force --version "$TARGET_VERSION"
+# # Install exact cargo-pgx that is definied in Cargo.toml
+# RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && cargo install cargo-pgx --force --version "$TARGET_VERSION"
 
-# Install llvm-tools-preview
-RUN rustup component add llvm-tools-preview rustc-dev
+# # Install llvm-tools-preview
+# RUN rustup component add llvm-tools-preview rustc-dev
 
-# Build and install plrustc
-RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin && find . -type d -name target | xargs rm -r
+# # Build and install plrustc
+# RUN cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin && find . -type d -name target | xargs rm -r
 
-# Init cargo pgx against installed postgres version
-RUN cargo pgx init --pg15 $(which pg_config)
+# # Init cargo pgx against installed postgres version
+# RUN cargo pgx init --pg15 $(which pg_config)
 
-# Build and install plrust as trusted
-RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --release --features trusted &&  find . -type d -name target | xargs rm -r
+# # Build and install plrust as trusted
+# RUN cd plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && cargo pgx install --release --features trusted && find . -type d -name target | xargs rm -r
+
+RUN TARGET_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name=="pgx")|.version') && \
+    cargo install cargo-pgx --force --version "$TARGET_VERSION" && \
+    rustup component add llvm-tools-preview rustc-dev && \
+    cd /src/plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin && \
+    cargo pgx init --pg15 $(which pg_config) && \
+    cd /src/plrust && STD_TARGETS="$(uname -m)-postgres-linux-gnu" ./build && \
+    cargo pgx install --release --features trusted && \
+    cd /src && find . -type d -name target | xargs rm -r && \
+    rustup component remove llvm-tools-preview rustc-dev
 
 # Reset the permissions of files/directories that was created or touched by the postgres user
 # Switching to the root user here temporarily is easier than installing and setting up sudo

--- a/Dockerfile.try
+++ b/Dockerfile.try
@@ -77,51 +77,43 @@ host all all 0.0.0.0/0 trust
 EOF
 
 # Set up plrust configuration options
-RUN cat <<EOF >> /etc/postgresql/15/main/postgresql.conf
-shared_preload_libraries='plrust'
-plrust.work_dir='/tmp'
-EOF
+RUN echo "shared_preload_libraries='plrust'" >> /etc/postgresql/15/main/postgresql.conf && \
+    echo "plrust.work_dir='/tmp'" >>/etc/postgresql/15/main/postgresql.conf
 
 # Set up custom prompt
-RUN cat <<EOF >> ~/.psqlrc
-\set PROMPT1 '%/(plrust)=# '
-\set PROMPT2 '%/(plrust)-# '
-EOF
+RUN echo "\set PROMPT1 '%/(plrust)=# '" >> ~/.psqlrc && \
+    echo "\set PROMPT2 '%/(plrust)-# '" >> ~/.psqlrc
 
 # Create startup/CMD scripts
 RUN mkdir ~/scripts
 ENV PATH="~/scripts:${PATH}"
 
 # Set up script that launches both postgresql server (background) and psql client (foreground)
-RUN cat <<EOF >> ~/scripts/all
-echo "Starting Postgresql..."
-service postgresql start
-echo ""
-echo "Installing plrust"
-psql -c "CREATE EXTENSION IF NOT EXISTS plrust;"
-echo ""
-echo "Starting psql"
-echo ""
-psql
-EOF
+RUN echo 'echo "Starting Postgresql..."' >> ~/scripts/all && \
+    echo 'service postgresql start' >> ~/scripts/all && \
+    echo 'echo ""' >> ~/scripts/all && \
+    echo 'echo "Installing plrust"' >> ~/scripts/all && \
+    echo 'psql -c "CREATE EXTENSION IF NOT EXISTS plrust;"' >> ~/scripts/all && \
+    echo 'echo ""' >> ~/scripts/all && \
+    echo 'echo "Starting psql"' >> ~/scripts/all && \
+    echo 'echo ""' >> ~/scripts/all && \
+    echo 'psql' >> ~/scripts/all
 
 RUN chmod +x ~/scripts/all
 
 # Set up script that launches Postgresql in the foreground. Need to launch it as a service first so that
 # plrust can be installed.
-RUN cat <<EOF >> ~/scripts/server
-echo "Starting Postgresql service..."
-service postgresql start
-echo ""
-echo "Installing plrust"
-psql -c "CREATE EXTENSION IF NOT EXISTS plrust;"
-echo ""
-echo "Stopping service"
-service postgresql stop
-echo "Starting Postgresql in the foreground"
-echo ""
-postgres -D /etc/postgresql/15/main/
-EOF
+RUN echo 'echo "Starting Postgresql service..."' >> ~/scripts/server && \
+    echo 'service postgresql start' >> ~/scripts/server && \
+    echo 'echo ""' >> ~/scripts/server && \
+    echo 'echo "Installing plrust"' >> ~/scripts/server && \
+    echo 'psql -c "CREATE EXTENSION IF NOT EXISTS plrust;"' >> ~/scripts/server && \
+    echo 'echo ""' >> ~/scripts/server && \
+    echo 'echo "Stopping service"' >> ~/scripts/server && \
+    echo 'service postgresql stop' >> ~/scripts/server && \
+    echo 'echo "Starting Postgresql in the foreground"' >> ~/scripts/server && \
+    echo 'echo ""' >> ~/scripts/server && \
+    echo 'postgres -D /etc/postgresql/15/main/' >> ~/scripts/server
 
 RUN chmod +x ~/scripts/server
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Install Prerequisites](./install-prerequisites.md)
 - [Install PL/Rust](./install-plrust.md)
 - [Update PL/Rust](./update-plrust.md)
+- [Try PL/Rust with Docker](./try-plrust-with-docker.md)
 
 
 # PL/Rust Usage

--- a/doc/src/try-plrust-with-docker.md
+++ b/doc/src/try-plrust-with-docker.md
@@ -1,29 +1,29 @@
 # Try PL/Rust with Docker
 
-If you would like to give PL/Rust a try without succumbing to the long arduous process of installing everything that is required, then this next section is for you!
+Giving PL/Rust a try has never been easier with Docker! This document outlines what is required to get a functional Postgres + PL/Rust environment running with just a few commands.
 
-The PL/Rust repository contains a Dockerfile named `Dockerfile.try` that contains everything you need to spin up and test PL/Rust in your own environment.
+The PL/Rust repository contains a Dockerfile named `Dockerfile.try` that contains everything necessary to spin up and test PL/Rust in a target environment.
 
-The following instructions assume that you have a very basic understanding of what [Docker](https://www.docker.com) is and that you already have it installed. If you do not have Docker installed yet, instructions for your particular environment can be found here: <https://docs.docker.com/engine/install/>
+The following instructions assume a very basic understanding of what [Docker](https://www.docker.com) is and that it is already installed in the target environment. If Docker is not yet installed yet, instructions can be found here: <https://docs.docker.com/engine/install/>
 
 1. Check out the PL/Rust code, and switch to that directory
 1. From a command line, run the following from the root of the checkout directory (note that `sudo` or equivalent may be required):
     ```
     docker build -f Dockerfile.try -t tcdi/try-plrust .
     ```
-1. Go grab your favorite beverage, because this may take some time.
-1. Once that finished, run the following (`sudo` may be required here):
+    Note that this may take a little while to finish.
+1. Once the above has finished, run the following (`sudo` may be required here):
     ```
     docker run -it tcdi/try-plrust
     ```
-1. You will see some output that the Postgres server has started, and you will be presented with a `psql` prompt:
+1. There will be some output that the Postgres server has started, and `psql` prompt will start up in the foreground:
     ```
     Type "help" for help.
 
     postgres(plrust)=#
     ```
 
-That's it! From here, you can try out PL/Rust with the interactive prompt. Here is a very small example to get you started:
+That's it! From here, the `psql` interactive prompt with PL/Rust installed can be used to create and run PL/Rust functions. Here is a very small example to get started:
 
 ```SQL
 CREATE FUNCTION plrust.one()
@@ -34,7 +34,7 @@ $$
 $$;
 ```
 
-Remember that creating PL/Rust functions cause compilation in the backend, so this may take some time depending on your hardware specifications. Once this completes, you can execute the function just as you would with any Postgres function:
+Creating PL/Rust functions causes Rust code compilation in the backend, so this may take some time depending on  the host's hardware specifications and internet connection speeds. Once this completes, the PL/Rust function can be executed similar to other Postgres functions:
 
 ```SQL
 SELECT * FROM plrust.one();
@@ -57,18 +57,22 @@ postgres(plrust)=# quit
 
 ## Alternate running modes
 
-Running the Docker container using `docker run -it tcdi/try-plrust` as described  above will spin up both the Postgres server in the background and the `psql` command line utility in the foreground in the same running environment. However, if you'd like to use the Postgres server only (with PL/Rust installed) so that you can use your favorite Postgres client of choice, you can run the following (which may require `sudo` or equivalent):
+Running the Docker container using `docker run -it tcdi/try-plrust` as described above will spin up both the Postgres server in the background and the `psql` command line utility in the foreground in the same running container. However, the option exists to run the Postgres server only (with PL/Rust installed) so that an alternative Postgres client can be used. To do this, run the following command (which may require `sudo` or equivalent):
 
 ```
 docker run -it -p 5432:5432 tcdi/try-plrust server
 ```
 
-This will set up everything that is necessary and run the Postgres server only, binding to TCP port 5432. The final `server` argument in the command indicates that it should launch the `server` script upon container bootup.
+This will set up everything that is necessary and run the Postgres server only, binding to TCP port 5432. Output here will be all of the Postgres log entries, including any errors that result from a PL/Rust compilation error. The final `server` argument in the command indicates that it should launch the `server` script upon container bootup. In order to connect with an alternative client, the only pieces of information that are required are the Postgres username (`postgres`), the hostname or IP address (e.g. `localhost` or `192.168.0.2`) and the port (`5432`). There is no password set for the `postgres` user in this setup. An example Postgres URI might look like this:
 
-To exit out of server mode, press Ctrl+c.
+```
+postgres://postgres@localhost:5432
+```
+
+To exit out of server mode, press Ctrl+c in the running Docker container.
 
 ## Caveats
 
-* This Docker setup does not take many security precautions into consideration. As such, the way `Dockerfile.try` is constructed should not be considered a best practice as it relates to setting up and securing a Postgres instance with PL/Rust installed. The resulting container that gets built from this should not be considered secure, and thus should not be used in any production environment whatsoever.
+* This Dockerfile and resulting image should not be used in production. It does not take many security precautions into consideration. As such, the way `Dockerfile.try` is constructed should not be considered a best practice as it relates to setting up and securing a Postgres instance with PL/Rust installed.
 
-* Mapping internal Postgres directories to the host environment through [bind mounts](https://docs.docker.com/storage/bind-mounts/) or [volumes](https://docs.docker.com/storage/volumes/) is a bit tricky since Postgres doesn't like many things owned and ran by root. Because of this, any functions and data created in a session started by `docker run ...` will be destroyed upon container termination.
+* The Postgres data directories, logs and built PL/Rust functions are not persistent and are destroyed upon continer termination. Externally mounting Postgres' data, log and function directories is outside the scope of this example.

--- a/doc/src/try-plrust-with-docker.md
+++ b/doc/src/try-plrust-with-docker.md
@@ -1,0 +1,74 @@
+# Try PL/Rust with Docker
+
+If you would like to give PL/Rust a try without succumbing to the long arduous process of installing everything that is required, then this next section is for you!
+
+The PL/Rust repository contains a Dockerfile named `Dockerfile.try` that contains everything you need to spin up and test PL/Rust in your own environment.
+
+The following instructions assume that you have a very basic understanding of what [Docker](https://www.docker.com) is and that you already have it installed. If you do not have Docker installed yet, instructions for your particular environment can be found here: <https://docs.docker.com/engine/install/>
+
+1. Check out the PL/Rust code, and switch to that directory
+1. From a command line, run the following from the root of the checkout directory (note that `sudo` or equivalent may be required):
+    ```
+    docker build -f Dockerfile.try -t tcdi/try-plrust .
+    ```
+1. Go grab your favorite beverage, because this may take some time.
+1. Once that finished, run the following (`sudo` may be required here):
+    ```
+    docker run -it tcdi/try-plrust
+    ```
+1. You will see some output that the Postgres server has started, and you will be presented with a `psql` prompt:
+    ```
+    Type "help" for help.
+
+    postgres(plrust)=#
+    ```
+
+That's it! From here, you can try out PL/Rust with the interactive prompt. Here is a very small example to get you started:
+
+```SQL
+CREATE FUNCTION plrust.one()
+    RETURNS INT LANGUAGE plrust
+AS
+$$
+    Ok(Some(1))
+$$;
+```
+
+Remember that creating PL/Rust functions cause compilation in the backend, so this may take some time depending on your hardware specifications. Once this completes, you can execute the function just as you would with any Postgres function:
+
+```SQL
+SELECT * FROM plrust.one();
+```
+
+which will provide the following results:
+
+```
+postgres(plrust)=# SELECT * FROM plrust.one();
+ one
+-----
+   1
+(1 row)
+```
+
+To exit out of the prompt and the Docker container, type the Postgres command `quit`:
+```
+postgres(plrust)=# quit
+```
+
+## Alternate running modes
+
+Running the Docker container using `docker run -it tcdi/try-plrust` as described  above will spin up both the Postgres server in the background and the `psql` command line utility in the foreground in the same running environment. However, if you'd like to use the Postgres server only (with PL/Rust installed) so that you can use your favorite Postgres client of choice, you can run the following (which may require `sudo` or equivalent):
+
+```
+docker run -it -p 5432:5432 tcdi/try-plrust server
+```
+
+This will set up everything that is necessary and run the Postgres server only, binding to TCP port 5432. The final `server` argument in the command indicates that it should launch the `server` script upon container bootup.
+
+To exit out of server mode, press Ctrl+c.
+
+## Caveats
+
+* This Docker setup does not take many security precautions into consideration. As such, the way `Dockerfile.try` is constructed should not be considered a best practice as it relates to setting up and securing a Postgres instance with PL/Rust installed. The resulting container that gets built from this should not be considered secure, and thus should not be used in any production environment whatsoever.
+
+* Mapping internal Postgres directories to the host environment through [bind mounts](https://docs.docker.com/storage/bind-mounts/) or [volumes](https://docs.docker.com/storage/volumes/) is a bit tricky since Postgres doesn't like many things owned and ran by root. Because of this, any functions and data created in a session started by `docker run ...` will be destroyed upon container termination.

--- a/doc/src/try-plrust-with-docker.md
+++ b/doc/src/try-plrust-with-docker.md
@@ -34,7 +34,7 @@ $$
 $$;
 ```
 
-Creating PL/Rust functions causes Rust code compilation in the backend, so this may take some time depending on  the host's hardware specifications and internet connection speeds. Once this completes, the PL/Rust function can be executed similar to other Postgres functions:
+Creating PL/Rust functions compiles Rust code in the backend, so this may take some time depending on the host's hardware specifications and internet connection speeds. Once this completes, the PL/Rust function can be executed similar to other Postgres functions:
 
 ```SQL
 SELECT * FROM plrust.one();

--- a/plrust/build
+++ b/plrust/build
@@ -49,5 +49,3 @@ fi
     STD_TARGETS="$STD_TARGETS" ./run clean
     STD_TARGETS="$STD_TARGETS" ./run install
 )
-
-cargo test --verbose --no-default-features --features "pg${PG_VER:-15} trusted"


### PR DESCRIPTION
Because plrust is a bit convoluted to build and run, we are introducing a Dockerfile that, when ran, should containerize everything necessary with one command so that anyone can test plrust locally. This should not ever be used for any production system, as the Postgres server being set up in this container has essentially 0 security considerations.