### PR TITLE
Function Capabilities & Zero Copy Arrays

### DIFF
--- a/plrust-trusted-pgrx/src/lib.rs
+++ b/plrust-trusted-pgrx/src/lib.rs
@@ -25,6 +25,9 @@ pub mod datum {
     // // dates & times
     // pub use ::pgrx::datum::{Date, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone};
 
+    // zero-copy Arrays
+    pub use ::pgrx::datum::{Array, ArrayIntoIterator, ArrayIterator, ArrayTypedIterator};
+
     // json
     pub use ::pgrx::datum::{Json, JsonB};
 

--- a/plrust/src/user_crate/capabilities.rs
+++ b/plrust/src/user_crate/capabilities.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// The capabilities that influence how PL/Rust generates wrapper code for a user function
+// NB:  Make sure to add new ones down below to [`FunctionCapabilitySet::default()`]
+#[derive(Debug, Clone, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq, Hash)]
+pub(crate) enum FunctionCapability {
+    /// Indicates that `pgrx::Array<'a, T>` should be used instead of `Vec<T>` for mapping
+    /// arguments of SQL type `ARRAY[]::T[]`
+    ZeroCopyArrays,
+}
+
+/// A set of [`FunctionCapability`] which is stored as metadata in the system catalogs
+#[derive(Debug, Clone, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq, Hash)]
+pub(crate) struct FunctionCapabilitySet(BTreeSet<FunctionCapability>);
+
+impl Default for FunctionCapabilitySet {
+    /// Creates a default [`FunctionCapabilitySet`] which contains every [`FunctionCapability`]
+    /// PL/Rust supports.  
+    #[inline]
+    fn default() -> Self {
+        let mut caps = BTreeSet::default();
+        caps.insert(FunctionCapability::ZeroCopyArrays);
+        Self(caps)
+    }
+}
+
+impl FunctionCapabilitySet {
+    /// Create a [`FunctionCapabilitySet`] that contains nothing.  This is a convenience method
+    /// for backwards compatibility with PL/Rust v1.0.0 which did not have capabilities
+    #[inline]
+    pub(crate) fn empty() -> Self {
+        Self(Default::default())
+    }
+
+    /// Does the set contain the [`FunctionCapability::ZeroCopyArrays]` capability?
+    #[inline]
+    pub fn has_zero_copy_arrays(&self) -> bool {
+        self.0.contains(&FunctionCapability::ZeroCopyArrays)
+    }
+}


### PR DESCRIPTION
Adds a `capabilities` property to our `pg_proc.prosrc` json structure and defines an enum of known function capabilities, which right now only contains `ZeroCopyArrays`.

If a function is re-compiled (really only via a pg_restore) then we'll use the set of old capabilities and adjust the wrapper code accordingly.

New functions get the `ZeroCopyArrays` capability by default, which uses `pgrx::Array<'a, T>` instead of `Vec<T>`, which old functions would have been using.

Also adds `pgrx::Array` and friends to `plrust-trusted-pgrx`.