### PR TITLE
 Composite type support. 

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Data types](./data-types.md)
     - [No Unsigned Types](./data-types/no-unsigned-types.md)
     - [Arrays](./data-types/arrays.md)
+    - [User Defined Types](./data-types/udts.md)
 - [Built-in functions](./built-in-functions.md)
     - [Logging to PostgreSQL from PL/Rust](./logging.md)
     - [Triggers](./triggers.md)

--- a/doc/src/data-types/udts.md
+++ b/doc/src/data-types/udts.md
@@ -1,0 +1,123 @@
+# User Defined Types
+
+PL/Rust supports using User Defined Types (UDTs; sometimes referred to as "composite types") in `LANGUAGE plrust` functions.
+UDTs can be used as arguments and return types.
+
+The general approach with UDTs is to first define one in SQL:
+
+```sql
+CREATE TYPE person AS (
+    name text,
+    age  float8
+);
+```
+
+`person` can now be used in any PL/Rust function.  To instantiate a new `person`:
+
+```sql
+create function make_person(name text, age float8) returns person
+    strict parallel safe
+    language plrust as
+$$
+    // create the Heap Tuple representation of the SQL type `person`
+    let mut p = PgHeapTuple::new_composite_type("person")?;
+    
+    // set a few of its attributes
+    //
+    // Runtime errors can occur if the attribute name is invalid or if the Rust type of the value
+    // is not compatible with the backing SQL type for that attribute.  Hence the use of the `?` operator
+    p.set_by_name("name", name)?;
+    p.set_by_name("age", age)?;
+    
+    // return the `person`
+    Ok(Some(p))
+$$;
+```
+
+Individual field accessors for the properties are straight-forward:
+
+```sql
+create function get_person_name(p person) returns text
+    strict parallel safe
+    language plrust as
+$$
+   // `p` is a `PgHeapTuple` over the underlying data for `person`
+   Ok(p.get_by_name("name")?)
+$$;
+
+create function get_person_age(p person) returns float8
+    strict parallel safe
+    language plrust as
+$$
+   // `p` is a `PgHeapTuple` over the underlying data for `person`
+   Ok(p.get_by_name("age")?)
+$$;
+```
+
+A generic accessor, for example requires encoding knowledge of the UDT structure, but provides quite a bit of flexibility.  
+
+Note that this function `returns text`.  This is a common denominator type to represent the various attribute types used 
+by `person`.  Fortunately, Postgres and PL/Rust have fantastic support for converting values to text/Strings:
+
+```sql
+create function get_person_attribute(p person, attname text) returns text
+    strict parallel safe
+    language plrust as
+$$
+   match attname.to_lowercase().as_str() {
+    "age" => {
+        let age:Option<f64> = p.get_by_name("age")?;
+        Ok(age.map(|v| v.to_string()))
+    },
+    "name" => {
+        Ok(p.get_by_name("name")?)
+    },
+    _ => panic!("unknown attribute: `{attname}`")
+   }
+$$;
+```
+
+This lends itself nicely to creating a custom operator to extract a `person`'s named attribute.
+
+```sql
+create operator ->> (function = get_person_attribute, leftarg = person, rightarg = text);
+```
+
+Tying these pieces together:
+
+```sql
+
+-- assume all of the above sql has been executed
+
+create table people
+(
+    id serial8 not null primary key,
+    p  person
+);
+
+insert into people (p) values (make_person('Johnny', 46.24));
+insert into people (p) values (make_person('Joe', 99.09));
+insert into people (p) values (make_person('Dr. Beverly Crusher of the Starship Enterprise', 32.0));
+
+select p ->> 'name' as name, (p ->> 'age')::float8 as age from people;
+                      name                      |  age  
+------------------------------------------------+-------
+ Johnny                                         | 46.24
+ Joe                                            | 99.09
+ Dr. Beverly Crusher of the Starship Enterprise |    32
+(3 rows)
+```
+
+## Discussion
+
+In Rust, [`PgHeapTuple`](https://docs.rs/plrust-trusted-pgrx/latest/plrust_trusted_pgrx/heap_tuple/struct.PgHeapTuple.html) 
+is the type that generically represents all UDTs.
+
+`PgHeapTuple` provides the ability to construct a new UDT by its SQL name.  It also provides attribute getter and setter methods
+for reading and mutating attributes.  
+
+Attributes can be addressed by name or one-based index.  Typical errors such as specifying an attribute name that doesn't 
+exist, an index that is out of bounds, or a Rust type for the value that is not compatible with that attribute's SQL type 
+will return a [`TryFromDatumError`](https://docs.rs/plrust-trusted-pgrx/latest/plrust_trusted_pgrx/heap_tuple/enum.TryFromDatumError.html).
+An early-return that error using the `?` operator (as demonstrated in the examples above) or matching on the error are
+both fine ways of handling such errors.

--- a/doc/src/data-types/udts.md
+++ b/doc/src/data-types/udts.md
@@ -54,7 +54,7 @@ $$
 $$;
 ```
 
-A generic accessor, for example requires encoding knowledge of the UDT structure, but provides quite a bit of flexibility.  
+A generic accessor, for example, requires encoding knowledge of the UDT structure, but provides quite a bit of flexibility.  
 
 Note that this function `returns text`.  This is a common denominator type to represent the various attribute types used 
 by `person`.  Fortunately, Postgres and PL/Rust have fantastic support for converting values to text/Strings:

--- a/plrust-trusted-pgrx/src/lib.rs
+++ b/plrust-trusted-pgrx/src/lib.rs
@@ -67,6 +67,7 @@ pub use heap_tuple::*;
 /// Support for arbitrary composite types as a "heap tuple".
 pub mod heap_tuple {
     pub use ::pgrx::composite_type;
+    pub use ::pgrx::datum::TryFromDatumError;
     pub use ::pgrx::heap_tuple::PgHeapTuple;
 }
 

--- a/plrust-trusted-pgrx/src/lib.rs
+++ b/plrust-trusted-pgrx/src/lib.rs
@@ -66,6 +66,7 @@ pub use heap_tuple::*;
 
 /// Support for arbitrary composite types as a "heap tuple".
 pub mod heap_tuple {
+    pub use ::pgrx::composite_type;
     pub use ::pgrx::heap_tuple::PgHeapTuple;
 }
 
@@ -87,7 +88,7 @@ pub mod memcxt {
 pub use pgbox::*;
 #[doc(hidden)]
 pub mod pgbox {
-    pub use ::pgrx::pgbox::{PgBox, WhoAllocated};
+    pub use ::pgrx::pgbox::{AllocatedByPostgres, AllocatedByRust, PgBox, WhoAllocated};
 }
 
 pub use pg_sys::panic::ErrorReportable;


### PR DESCRIPTION
This will replace PR #57 when complete.

Here's an example:

```sql
drop type person cascade;
drop table people cascade;
create type person as (name text, age float8);
create function make_person(name text, age float8) returns person strict parallel safe language plrust as $$
    let mut p = PgHeapTuple::new_composite_type("person")?;
    p.set_by_name("name", name)?;
    p.set_by_name("age", age)?;
    Ok(Some(p))
$$;

create function get_person_name(p person) returns text strict parallel safe language plrust as $$
   Ok(p.get_by_name("name")?)
$$;
create function get_person_age(p person) returns float8 strict parallel safe language plrust as $$
   Ok(p.get_by_name("age")?)
$$;
create function get_person_property(p person, prop text) returns text strict parallel safe language plrust as $$
   match prop.to_lowercase().as_str() {
    "age" => {
        let age:Option<f64> = p.get_by_name("age")?;
        Ok(age.map(|v| v.to_string()))
    },
    "name" => {
        Ok(p.get_by_name("name")?)
    },
    _ => panic!("unknown property: `{prop}`")
   }
$$;

create table people (
    id serial8 not null primary key,
    p person
);

insert into people (p) values (make_person('Eric', 46.24));
insert into people (p) values (make_person('Joe', 99.09));
insert into people (p) values (make_person('Dr. Beverly Crusher of the Starship Enterprise', 32.0));

select *, get_person_name(p), get_person_age(p) from people order by get_person_age(p) desc;

create operator -> (function = get_person_name, rightarg = person);
create operator -# (function = get_person_age, rightarg = person);

select ->p as name, -#p as age from people;

create operator ->> (function = get_person_property, leftarg = person, rightarg = text);
select p->>'name' as name, (p->>'age')::float8 as age from people;
```