### PR TITLE
Don't require a loaded function to have "compile lints" applied.

### DIFF
--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -27,8 +27,7 @@ pub(crate) static PLRUST_ALLOWED_DEPENDENCIES: GucSetting<Option<&'static str>> 
 static PLRUST_COMPILATION_TARGETS: GucSetting<Option<&'static str>> = GucSetting::new(None);
 pub(crate) static PLRUST_COMPILE_LINTS: GucSetting<Option<&'static str>> =
     GucSetting::new(Some(DEFAULT_LINTS));
-pub(crate) static PLRUST_REQUIRED_LINTS: GucSetting<Option<&'static str>> =
-    GucSetting::new(Some(DEFAULT_LINTS));
+pub(crate) static PLRUST_REQUIRED_LINTS: GucSetting<Option<&'static str>> = GucSetting::new(None);
 pub(crate) static PLRUST_TRUSTED_PGRX_VERSION: GucSetting<Option<&'static str>> =
     GucSetting::new(Some(env!(
         "PLRUST_TRUSTED_PGRX_VERSION",

--- a/plrust/src/user_crate/lint.rs
+++ b/plrust/src/user_crate/lint.rs
@@ -127,7 +127,7 @@ pub(crate) fn required_lints() -> LintSet {
     // whatever might be configured in postgresql.conf
     let mut configured = PLRUST_REQUIRED_LINTS
         .get()
-        .unwrap_or_else(|| PLRUST_COMPILE_LINTS.get().unwrap_or_default())
+        .unwrap_or_default()
         .split(',')
         .filter_map(filter_map)
         .collect::<LintSet>();


### PR DESCRIPTION
Loading an existing, compiled function should not require that it was previously compiled with the set of lints PL/Rust now uses for compilation.  This prohibits newer versions of PL/Rust, which might have a new lint, from executing functions created with an older version without that lint.

We do, however, continue to require the lints that are set in both the `$PLRUST_REQUIRED_LINTS` envar and the `plrust.required_lints` postgresql.conf GUC.  This is a way for the administrator to flat out **require** certain lints be applied to **every** function before it can be loaded/executed.

PL/Rust's default stance, however, is that if it was good before, it's good now, even if new lints are applied going forward.