### PR TITLE
Remove the `unaligned_references` lint (issue #323)

### DIFF
--- a/doc/src/config-lints.md
+++ b/doc/src/config-lints.md
@@ -74,12 +74,6 @@ https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#suspicious-au
 
 This defends against some patterns that can lead to soundness issues. These cases currently can only trigger in patterns which are otherwise blocked by the `unsafe_code` lint, but for better defense-in-depth, it's explicitly forbidden in PL/Rust.
 
-### `unaligned_references`
-
-https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#unaligned-references
-
-The unaligned_references lint detects unaligned references to fields of packed structs. This forbidden because it is a soundness hole in the language.
-
 ### `soft_unstable`
 
 https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#soft-unstable

--- a/doc/src/config-pg.md
+++ b/doc/src/config-pg.md
@@ -158,7 +158,7 @@ purpose of the Lints.
 A comma-separated list of Rust lints to apply to every user function.
 
 ```bash
-plrust.compile_lints = 'plrust_extern_blocks, plrust_lifetime_parameterized_traits, implied_bounds_entailment, unsafe_code, plrust_filesystem_macros, plrust_env_macros, plrust_external_mod, plrust_fn_pointers, plrust_async, plrust_leaky, plrust_print_macros, plrust_stdio, unknown_lints, deprecated, suspicious_auto_trait_impls, unaligned_references, soft_unstable, plrust_autotrait_impls'
+plrust.compile_lints = 'plrust_extern_blocks, plrust_lifetime_parameterized_traits, implied_bounds_entailment, unsafe_code, plrust_filesystem_macros, plrust_env_macros, plrust_external_mod, plrust_fn_pointers, plrust_async, plrust_leaky, plrust_print_macros, plrust_stdio, unknown_lints, deprecated, suspicious_auto_trait_impls, soft_unstable, plrust_autotrait_impls'
 ```
 
 

--- a/doc/src/functions/anatomy.md
+++ b/doc/src/functions/anatomy.md
@@ -37,7 +37,6 @@ mod forbidden {
        #![forbid(plrust_suspicious_trait_object)]
        #![forbid(soft_unstable)]
        #![forbid(suspicious_auto_trait_impls)]
-       #![forbid(unaligned_references)]
        #![forbid(unsafe_code)]
        #![forbid(where_clauses_object_safety)]
     

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -99,7 +99,6 @@ const DEFAULT_LINTS: &'static str = "\
     unsafe_code, \
     deprecated, \
     suspicious_auto_trait_impls, \
-    unaligned_references, \
     where_clauses_object_safety, \
     soft_unstable\
 ";


### PR DESCRIPTION
As of rust 1.69, the `unaligned_references` lint is depcreated as it's just built into the compiler.

PL/Rust now uses rust 1.70, so we don't need it.  Removing it eliminates a compliation warning on user functions too.