### PR TITLE
In response to issue #325, rework the dependency allow-list.

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -33,5 +33,6 @@
 
 - [Architecture](./architecture.md)
 - [Designing for Trust](./designing-for-trust.md)
+- [External Dependencies](./dependencies.md)
 - [Lints](./config-lints.md)
 - [Environment variables](./config-env-var.md)

--- a/doc/src/config-pg.md
+++ b/doc/src/config-pg.md
@@ -51,18 +51,7 @@ PL/Rust functions.
 When `plrust.allowed_dependencies` is not defined, all Rust crates are allowed
 when creating PL/Rust functions.
 
-Consider a file `/path/to/plrust_allowed.toml` with the following contents.
-
-```toml
-foo = "1.1.5"
-```
-
-The configuration to restrict crates looks like the following example.
-
-```bash
-plrust.allowed_dependencies = /path/to/plrust_allowed.toml
-```
-
+For more discussion, see [dependencies.md](dependencies.md)
 
 #### `plrust.path_override` (string)
 

--- a/doc/src/dependencies.md
+++ b/doc/src/dependencies.md
@@ -39,11 +39,11 @@ rand = ">=0.8, <0.9"
 bitvec = [">=1, <2", "=0.2", { version = "1.0.1", features = [ "alloc" ], default-features = false }]
 ```
 
-The reason for this added flexibility to allow the administrator to declare the most precise crate version they wish
-along with that version's specific set of features and other dependency properties.
+The added flexibility allows administrators to declare the most precise crate version they wish along with that 
+version's specific set of features and other dependency properties.
 
-When a `LANGUAGE plrust` function specifies a dependency and version, it finds the largest (presumably "most recent")
-allowed version that matches what the user's plrust function requested.  More on this below.
+When a `LANGUAGE plrust` function specifies a dependency and version, the largest (presumably "most recent") configured 
+version matching the user's plrust function is used.  More on this below.
 
 ### Version Requirement Format
 
@@ -66,36 +66,37 @@ rand = "0.8.5"
 serde = ">1.1"
 ```
 
-The reason for this is that `cargo` is allowed to pick a slightly different version depending on how it was specified.
-With exact or bounded values, `cargo` becomes limited to what the administrator has decided is allowed.
+`cargo` is allowed to pick a slightly different version depending on how it was specified -- with exact and bounded 
+values, `cargo` becomes limited to what administrators decide is allowed.
 
 Using the bare wildcard pattern (`*`) is allowed and has a special meaning as it relates to a user `LANGUAGE plrust`
 function.
 
 ### Using a Dependency
 
-As demonstrated above, a `LANGUAGE plrust` function can have a `[dependencies]` section.  The function author is encouraged
-to specify exact versions for each desired dependency, and PL/Rust will use that version if it is found to match one
-of the allow-list entries for that dependency.
+As demonstrated above, a `LANGUAGE plrust` function can have a `[dependencies]` section.  Function authors are encouraged
+to specify exact versions for each desired dependency.  PL/Rust will use that exact version if it is found to match one
+of the allow-list entries.
 
-If the user requests a full, dotted triplet version such as `1.2.3` that is found to match one of the allow-list version
-requirements, then PL/Rust will transparently rewrite it to be that exact version; it will become `=1.2.3`.
+If the user requests a dotted triplet version such as `1.2.3` and it matches an allow-list entry PL/Rust will 
+transparently rewrite it to be that exact version; it will become `=1.2.3`.
 
-If the allow-list simply contains a wildcard version, for example:
+If the allow-list simply contains a wildcard version...
 
 ```toml
 rand = "*"
 ```
 
-And the user function requests a non-wildcard version such as `0.8.5`, then PL/Rust will use that specific version.  If
-the reverse is the case where the allow-list contains one or more specific version requirements, such as:
+... and the user function requests a non-wildcard version such as `0.8.5`, PL/Rust will use that specific version.  
+
+If the reverse, where the allow-list contains one or more specific version requirements, such as...
 
 ```toml
 rand = [ "0.8.5", "0.6" ]
 ```
 
-And the PL/Rust function requests a wildcard (ie, `rand = "*"`), then PL/Rust will choose the largest version requirement
-from the allow-list.  In this case, that would be `0.8.5`.
+... and the PL/Rust function requests a wildcard (ie, `rand = "*"`), then PL/Rust will choose the largest version
+requirement from the allow-list.  In this case, that would be `0.8.5`.
 
 ### Working with Crate Features
 
@@ -103,9 +104,9 @@ When a user function uses an allow-list restricted crate, the allow-list control
 dependency properties such as `features` and `default-features`.  A user function cannot override these.  It can specify
 them, but they must exactly match what is found in the allow-list.
 
-This restriction allows the administrator to have full control over how a dependency can be used.
+This restriction allows administrators full control over how dependencies may be used.
 
-For example, is fine for a user function:
+For example, this fine for a user function:
 
 ```sql
 CREATE OR REPLACE FUNCTION randint(seed bigint) RETURNS bigint STRICT LANGUAGE plrust AS $$
@@ -145,13 +146,12 @@ Ok(Some(rng.next_u64() as _))
 $$;
 ```
 
-### Operations Notes
+### Operational Notes
 
 - The dependency allow-list file must be configured in `postgresql.conf` where its full path is the value of the 
 `plrust.allowed_dependencies` GUC.
 
-- This file must be readable by the user that Postgres backend connections are run as.  Typically, the user named is named
-`postgres`.
+- This file must be readable by the user that Postgres backend connections are run.  Typically, the user is named `postgres`.
 
 - The file is read, parsed, and validated every time a `CREATE FUNCTION ... LANGUAGE plrust` statement is executed.  Doing
 so allows an administrator to modify it without requiring a Postgres cluster restart. 

--- a/doc/src/dependencies.md
+++ b/doc/src/dependencies.md
@@ -1,0 +1,157 @@
+# External Dependencies
+
+PL/Rust supports using external dependencies.  Out of the box, even as a Trusted Language Handler, this is unrestricted.
+A user function may specify any dependency they wish.
+
+For example:
+
+```sql
+CREATE OR REPLACE FUNCTION randint() RETURNS bigint LANGUAGE plrust AS $$
+[dependencies]
+rand = "0.8"
+
+[code]
+use rand::Rng; 
+Ok(Some(rand::thread_rng().gen())) 
+$$;
+```
+
+It is suggested that administrators create a dependency allow-list file and configure its path in `postgresql.conf` with
+the `plrust.allowed_dependencies` setting.
+
+If external dependencies are not wanted at all, create a zero-byte file or point the configuration to `/dev/null`.
+
+## Allow-list Format
+
+PL/Rust's dependency allow-list is a TOML file whose format is akin to a standard `Cargo.toml`'s `[dependencies]` section.
+The format is a little different, however, and imposes some requirements on the version strings specified.
+
+### The Format
+
+The file format is a list of `dependency_name = version_requirement` pairs, however `version_requirement` can take a few different
+forms.  It can be a quoted string, such as `"=1.2.3"`, a TOML table, such as `{ version = "=1.2.3", features = ["a", "b", "c"] } }`,
+or an array of either of those, such as `[ "=1.2.3", { version = "=1.2.3" }, ">=4, <5"`.
+
+As an example, this is a valid allow-list file:
+
+```toml
+rand = ">=0.8, <0.9"
+bitvec = [">=1, <2", "=0.2", { version = "1.0.1", features = [ "alloc" ], default-features = false }]
+```
+
+The reason for this added flexibility to allow the administrator to declare the most precise crate version they wish
+along with that version's specific set of features and other dependency properties.
+
+When a `LANGUAGE plrust` function specifies a dependency and version, it finds the largest (presumably "most recent")
+allowed version that matches what the user's plrust function requested.  More on this below.
+
+### Version Requirement Format
+
+PL/Rust uses Cargo's interpretation of semver to manage dependency versions, however PL/Rust dictates that each version
+requirement must either be a single exact value such as `=1.2.3`, a bounded range such as `>=1, <2`, or a bare wildcard
+(ie, `*`).
+
+For example, these are valid version requirement values:
+
+```toml
+rand = "=0.8.5"
+serde = ">=1.0.151, <1.1"
+bitvec = "*"
+```
+
+These are not:
+
+```toml
+rand = "0.8.5"
+serde = ">1.1"
+```
+
+The reason for this is that `cargo` is allowed to pick a slightly different version depending on how it was specified.
+With exact or bounded values, `cargo` becomes limited to what the administrator has decided is allowed.
+
+Using the bare wildcard pattern (`*`) is allowed and has a special meaning as it relates to a user `LANGUAGE plrust`
+function.
+
+### Using a Dependency
+
+As demonstrated above, a `LANGUAGE plrust` function can have a `[dependencies]` section.  The function author is encouraged
+to specify exact versions for each desired dependency, and PL/Rust will use that version if it is found to match one
+of the allow-list entries for that dependency.
+
+If the user requests a full, dotted triplet version such as `1.2.3` that is found to match one of the allow-list version
+requirements, then PL/Rust will transparently rewrite it to be that exact version; it will become `=1.2.3`.
+
+If the allow-list simply contains a wildcard version, for example:
+
+```toml
+rand = "*"
+```
+
+And the user function requests a non-wildcard version such as `0.8.5`, then PL/Rust will use that specific version.  If
+the reverse is the case where the allow-list contains one or more specific version requirements, such as:
+
+```toml
+rand = [ "0.8.5", "0.6" ]
+```
+
+And the PL/Rust function requests a wildcard (ie, `rand = "*"`), then PL/Rust will choose the largest version requirement
+from the allow-list.  In this case, that would be `0.8.5`.
+
+### Working with Crate Features
+
+When a user function uses an allow-list restricted crate, the allow-list controls, per version, the allowed set of 
+dependency properties such as `features` and `default-features`.  A user function cannot override these.  It can specify
+them, but they must exactly match what is found in the allow-list.
+
+This restriction allows the administrator to have full control over how a dependency can be used.
+
+For example, is fine for a user function:
+
+```sql
+CREATE OR REPLACE FUNCTION randint(seed bigint) RETURNS bigint STRICT LANGUAGE plrust AS $$
+[dependencies]
+rand = { version = "*", features = [ "small_rng" ], default-features = false }
+
+[code]
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use rand::RngCore;
+
+let mut rng = SmallRng::seed_from_u64(seed as _);
+Ok(Some(rng.next_u64() as _))
+$$;
+```
+
+As long as the allow-list contains the following:
+
+```toml
+rand = { version = "=0.8.5", features = [ "small_rng" ], default-features = false }
+```
+
+Note that since the allow-list declares the dependency features, the user function could have elided them:
+
+```sql
+CREATE OR REPLACE FUNCTION randint(seed bigint) RETURNS bigint STRICT LANGUAGE plrust AS $$
+[dependencies]
+rand = "*"
+
+[code]
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use rand::RngCore;
+
+let mut rng = SmallRng::seed_from_u64(seed as _);
+Ok(Some(rng.next_u64() as _))
+$$;
+```
+
+### Operations Notes
+
+- The dependency allow-list file must be configured in `postgresql.conf` where its full path is the value of the 
+`plrust.allowed_dependencies` GUC.
+
+- This file must be readable by the user that Postgres backend connections are run as.  Typically, the user named is named
+`postgres`.
+
+- The file is read, parsed, and validated every time a `CREATE FUNCTION ... LANGUAGE plrust` statement is executed.  Doing
+so allows an administrator to modify it without requiring a Postgres cluster restart. 

--- a/plrust/build
+++ b/plrust/build
@@ -29,7 +29,7 @@ cargo update -p pgrx
 cargo fetch
 if [ "$CI" != true ]; then
     cargo install cargo-pgrx \
-     --version "0.9.4" \
+     --version "0.9.5" \
      --locked # use the Cargo.lock in the pgrx repo
 fi
 

--- a/plrust/src/allow_list.rs
+++ b/plrust/src/allow_list.rs
@@ -1,0 +1,434 @@
+use crate::gucs::PLRUST_ALLOWED_DEPENDENCIES;
+use semver::{BuildMetadata, Comparator, Op, Version, VersionReq};
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+use std::iter::once;
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::str::FromStr;
+use toml::Value;
+
+#[derive(Debug, PartialEq)]
+pub struct Dependency {
+    name: String,
+    versions: BTreeMap<OrderedVersionReq, toml::value::Table>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct OrderedVersionReq(VersionReq);
+
+pub type AllowList = BTreeMap<String, Dependency>;
+
+impl Display for OrderedVersionReq {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<String> for OrderedVersionReq {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        OrderedVersionReq::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for OrderedVersionReq {
+    type Error = Error;
+
+    /// only allow "*", exact, and bounded VersionReq values
+    fn try_from(version: &str) -> Result<Self, Self::Error> {
+        let vreq = VersionReq::parse(&version)
+            .map_err(|e| Error::MalformedVersion(version.to_string(), e.to_string()))?;
+
+        return if vreq.comparators.len() == 0 {
+            // it's a "*" version
+            Ok(OrderedVersionReq(vreq))
+        } else if vreq.comparators.len() == 1 && vreq.comparators[0].op == Op::Exact {
+            // it's an exact version: "=x.y.z"
+            Ok(OrderedVersionReq(vreq))
+        } else if vreq.comparators.len() == 2
+            && matches!(vreq.comparators[0].op, Op::Greater | Op::GreaterEq)
+            && matches!(vreq.comparators[1].op, Op::Less | Op::LessEq)
+        {
+            // it's a bounded version: ">=a.b.c, <=x.y.z"
+            Ok(OrderedVersionReq(vreq))
+        } else {
+            Err(Error::UnsupportedVersionReq(version.to_string()))
+        };
+    }
+}
+
+impl Deref for OrderedVersionReq {
+    type Target = VersionReq;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Ord for OrderedVersionReq {
+    /// Orders [`VersionReq`] values from smallest to largest, with "*" considered the smallest
+    fn cmp(&self, other: &Self) -> Ordering {
+        let self_vers = self.as_versions();
+        let other_vers = other.as_versions();
+
+        if self_vers.is_empty() {
+            // '*' version is the smallest
+            return Ordering::Less;
+        } else if other_vers.is_empty() {
+            // '*' version is the smallest
+            return Ordering::Greater;
+        } else {
+            match self_vers[0].cmp(&other_vers[0]) {
+                // how do the upper bounds of each side compare?
+                Ordering::Equal if self_vers.len() > 1 && other_vers.len() > 1 => {
+                    self_vers[1].cmp(&other_vers[1])
+                }
+
+                // how does our value compare to the upper bound of the other?
+                Ordering::Equal if other_vers.len() > 1 => self_vers[0].cmp(&other_vers[1]),
+
+                // lower bounds compared unequal, so that's our final answer
+                ne => ne,
+            }
+        }
+    }
+}
+
+impl PartialOrd for OrderedVersionReq {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn fake_version(cmp: &Comparator) -> Version {
+    let mut version = Version {
+        major: cmp.major,
+        minor: cmp.minor.unwrap_or(0),
+        patch: cmp.patch.unwrap_or(0),
+        pre: cmp.pre.clone(),
+        build: BuildMetadata::EMPTY,
+    };
+
+    if cmp.op == Op::Greater {
+        version.patch += 1;
+    } else if cmp.op == Op::Less {
+        if version.patch > 0 {
+            version.patch -= 1;
+        } else if version.minor > 0 {
+            version.minor -= 1;
+        } else if version.major > 0 {
+            version.major -= 1;
+        }
+    }
+
+    version
+}
+
+impl OrderedVersionReq {
+    /// Return `true` if the inner [`VersionReq`] matches each of the individual [`Comparator`]s of
+    /// the `other` argument.
+    #[rustfmt::skip]
+    fn matches_versionreq(&self, other: &VersionReq) -> bool {
+        let other_lower = other.comparators.get(0);
+        let other_upper = other.comparators.get(1);
+
+        match (other_lower, other_upper) {
+            // user gave us a single version, so lets see if it matches us
+            (Some(lower), None) => self.0.matches(&fake_version(lower)),
+
+            // user gave us a bounded version, so lets make sure its lower and upper match ours
+            (Some(lower), Some(upper)) => {
+                let my_lower = self.0.comparators.get(0);
+                let my_upper = self.0.comparators.get(1);
+
+                match (my_lower, my_upper) {
+                    (Some(my_lower), Some(my_upper)) => my_lower.matches(&fake_version(lower)) && my_upper.matches(&fake_version(upper)),
+                    (Some(my_lower), None) => my_lower.matches(&fake_version(lower)) && my_lower.matches(&fake_version(upper)),
+                    (None, _) =>  true,
+                }
+            }
+
+            // user gave us a wildcard
+            (None, _) =>  true
+        }
+    }
+
+    /// Convert each part of the inner [`VersionReq`] into an exact [`Version`] the best we can.
+    /// For unknown fields, we assume zero.
+    fn as_versions(&self) -> Vec<Version> {
+        self.0.comparators.iter().map(fake_version).collect()
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+pub enum Error {
+    #[error("Unsupported value type: {0:?}")]
+    UnsupportedValueType(Value),
+    #[error("Dependency entry is missing the `version` attribute")]
+    VersionMissing,
+    #[error("Cannot read allow-list dependency file")]
+    CannotReadAllowList,
+    #[error("Not a TOML file")]
+    NotATomlFile,
+    #[error("`plrust.allowed_dependencies` is not set in `postgresql.conf`")]
+    NotConfigured,
+    #[error("The value of `plrust.allowed_dependencies` is not a valid path")]
+    InvalidPath,
+    #[error("`{0}` is malformed: {1}")]
+    MalformedVersion(String, String),
+    #[error("`{0}` is not permitted by the allow-list")]
+    VersionNotPermitted(String),
+    #[error("`{0}` is not a supported version requirement.  Use wildcard (`*`), exact (`=x.y.z`), or bounded ranges (`>=a.b.c, <=x.y.z`)")]
+    UnsupportedVersionReq(String),
+}
+
+impl TryFrom<(&str, Value)> for Dependency {
+    type Error = Error;
+
+    fn try_from(value: (&str, Value)) -> Result<Self, Self::Error> {
+        let name = value.0.to_string();
+        let value = value.1;
+
+        match value {
+            Value::String(version) => {
+                let version = OrderedVersionReq::try_from(version)?;
+                let mut table = toml::value::Table::new();
+                table.insert("version".to_string(), Value::String(version.to_string()));
+
+                Ok(Dependency {
+                    name,
+                    versions: BTreeMap::from_iter(once((version, table))),
+                })
+            }
+            Value::Array(versions) => {
+                let versions = versions
+                    .into_iter()
+                    .map(|value| match value {
+                        Value::String(version) => {
+                            let version = OrderedVersionReq::try_from(version)?;
+                            let mut table = toml::value::Table::new();
+                            table.insert("version".to_string(), Value::String(version.to_string()));
+
+                            Ok((version, table))
+                        }
+                        Value::Table(table) => match table.get("version") {
+                            Some(version) => {
+                                let version = version
+                                    .as_str()
+                                    .ok_or(Error::UnsupportedValueType(version.clone()))?;
+                                let version = OrderedVersionReq::try_from(version)?;
+                                Ok((version, table))
+                            }
+                            None => Err(Error::VersionMissing),
+                        },
+                        unsupported => Err(Error::UnsupportedValueType(unsupported)),
+                    })
+                    .collect::<Result<_, Error>>()?;
+
+                Ok(Dependency { name, versions })
+            }
+
+            Value::Table(table) => {
+                let version = table.get("version").ok_or(Error::VersionMissing)?;
+                let version = version
+                    .as_str()
+                    .ok_or(Error::UnsupportedValueType(version.clone()))?;
+                let version = OrderedVersionReq::try_from(version)?;
+                Ok(Dependency {
+                    name,
+                    versions: BTreeMap::from_iter(once((version, table))),
+                })
+            }
+
+            unknown => Err(Error::UnsupportedValueType(unknown)),
+        }
+    }
+}
+
+impl Dependency {
+    /// Given some kind of version string, which could be a literal version such as `1.2.3`, or
+    /// any [`semver::VersionReq`]-compatible version pattern, find the **largest** declared
+    /// version entry that matches the specified `wanted_version`.
+    ///
+    /// This function will return the most constrained or exact version number it can, whether that
+    /// is the caller's `wanted_version` or the VersionReq from the allow-list.  
+    ///
+    /// If the user asks for a literal version, such as "1.2.3" and there's a matching entry
+    /// (regardless of the VersionReq pattern), the version returned is "=1.2.3".  
+    ///
+    /// If the user asks for some kind of imprecise or pattern version number then the first matching
+    /// specification from the allow-list is returned.
+    ///
+    /// If the user asks for some kind of imprecise or pattern version and the matching allow-list
+    /// VersionReq is a wildcard pattern, then the user's `wanted_version` is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MalformedVersion`] if the `wanted_version` argument cannot be parsed into
+    /// either a [`semver::Version`] or a [`semver::VersionReq`].
+    ///
+    /// Returns [`Error::VersionNotPermitted`] if the `wanted_version` argument does not match any of the
+    /// declared versions in this [`Dependency`]
+    pub fn get_dependency_entry(&self, wanted_version: &str) -> Result<Value, Error> {
+        let wanted_version = wanted_version.trim().trim_start_matches('=');
+
+        let ranked_versions = self.versions.iter().rev(); // we iterate our versions in `.rev()` order to find the largest matching version
+
+        let mut table_entry = None;
+        match Version::parse(wanted_version) {
+            // it's a literal version number, such as 1.2.345
+            Ok(wanted_version) => {
+                for (version, table) in ranked_versions {
+                    if version.matches(&wanted_version) {
+                        // the version the user wants matches one of our allow-list versions
+                        // so we use the user's version, prefixed with an "=" so it's an exact version
+                        let mut table = table.clone();
+                        table.insert(
+                            "version".to_string(),
+                            Value::String(format!("={wanted_version}")),
+                        );
+
+                        table_entry = Some(table);
+                        break;
+                    }
+                }
+            }
+
+            // it's *probably* a VersionReq, so we'll handle this a little differently
+            Err(_) => {
+                let wanted_version = VersionReq::parse(wanted_version).map_err(|e| {
+                    Error::MalformedVersion(wanted_version.to_string(), e.to_string())
+                })?;
+
+                for (version, table) in ranked_versions {
+                    if version.matches_versionreq(&wanted_version) {
+                        let mut table = table.clone();
+
+                        if version.to_string().contains('*') {
+                            // the matching allow-list VersionReq is a wildcard pattern, so since the
+                            // `wanted_version` matches it, use the (probably) more precise `wanted_version`
+                            table.insert(
+                                "version".to_string(),
+                                Value::String(wanted_version.to_string()),
+                            );
+                        }
+
+                        table_entry = Some(table);
+                        break;
+                    }
+                }
+            }
+        }
+
+        table_entry
+            .map(|entry| Value::Table(entry))
+            .ok_or_else(|| Error::VersionNotPermitted(wanted_version.to_string()))
+    }
+}
+
+/// Reads the "dependency allow-list" from disk, at the path specified by the
+/// `plrust.allowed_dependencies` GUC
+pub fn load_allowlist() -> eyre::Result<AllowList> {
+    let path = PathBuf::from_str(
+        &PLRUST_ALLOWED_DEPENDENCIES
+            .get()
+            .ok_or(Error::NotConfigured)?,
+    )
+    .map_err(|_| Error::InvalidPath)?;
+
+    let contents = std::fs::read_to_string(path).map_err(|_| Error::CannotReadAllowList)?;
+    Ok(parse_allowlist(&contents)?)
+}
+
+pub(crate) fn parse_allowlist(contents: &str) -> Result<AllowList, Error> {
+    let toml = toml::from_str::<toml::value::Table>(&contents).map_err(|_| Error::NotATomlFile)?;
+    let mut allowed = AllowList::new();
+    for (depname, value) in toml {
+        let dependency = Dependency::try_from((depname.as_str(), value))?;
+        allowed.insert(depname, dependency);
+    }
+    Ok(allowed)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::allow_list::{parse_allowlist, Error, OrderedVersionReq};
+    use semver::VersionReq;
+
+    const TOML: &str = r#"
+a = [ "=1.2.3", "=3.0", ">=6.0.0, <=10", { version = "=2.4.5", features = [ "x", "y", "z" ] }, "*", ">=1.0.0, <5.0.0",">=1.0.0, <2.0.0", ">=2, <=4", "=2.99.99" ]
+b = "*"
+c = "=1.2.3"
+d = { version = "=3.4.5", features = [ "x", "y", "z" ] }
+    "#;
+
+    #[test]
+    fn test_allowlist_parse_good() {
+        assert!(parse_allowlist(TOML).is_ok());
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_allowlist_parse_invalid_version_values() {
+        assert_eq!(parse_allowlist("a = '=1.2.3.4.5'"), Err(Error::MalformedVersion("=1.2.3.4.5".to_string(), VersionReq::parse("=1.2.3.4.5").err().unwrap().to_string())));
+        assert_eq!(parse_allowlist("a = '1.2.3'"), Err(Error::UnsupportedVersionReq("1.2.3".to_string())));
+        assert_eq!(parse_allowlist("a = 42"), Err(Error::UnsupportedValueType(toml::Value::Integer(42))));
+        assert_eq!(parse_allowlist("a = { features = ['a', 'b', 'c'] }"), Err(Error::VersionMissing));
+    }
+
+    #[test]
+    fn test_allowlist_star() -> eyre::Result<()> {
+        let allowed = parse_allowlist(TOML)?;
+        let dep = allowed.get("b").expect("no dependency for `b`");
+        let versions = dep.versions.keys().cloned().collect::<Vec<_>>();
+        assert_eq!(versions, vec![OrderedVersionReq::try_from("*")?]);
+        dep.get_dependency_entry("*")?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_allowlist_versionreq_sort() -> eyre::Result<()> {
+        let allowed = parse_allowlist(TOML)?;
+        let dep = allowed.get("a").expect("no dependency for `a`");
+        let versions = dep.versions.keys().cloned().collect::<Vec<_>>();
+
+        assert_eq!(
+            versions,
+            vec![
+                OrderedVersionReq::try_from("*")?,
+                OrderedVersionReq::try_from(">=1.0.0, <2.0.0")?,
+                OrderedVersionReq::try_from(">=1.0.0, <5.0.0")?,
+                OrderedVersionReq::try_from("=1.2.3")?,
+                OrderedVersionReq::try_from(">=2, <=4")?,
+                OrderedVersionReq::try_from("=2.4.5")?,
+                OrderedVersionReq::try_from("=2.99.99")?,
+                OrderedVersionReq::try_from("=3.0")?,
+                OrderedVersionReq::try_from(">=6.0.0, <=10")?,
+            ]
+        );
+        Ok(())
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_allowlist_version_formats() -> eyre::Result<()> {
+        assert_eq!(OrderedVersionReq::try_from("1.2.3"), Err(Error::UnsupportedVersionReq("1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from("^1.2.3"), Err(Error::UnsupportedVersionReq("^1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from("~1.2.3"), Err(Error::UnsupportedVersionReq("~1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from(">1.2.3"), Err(Error::UnsupportedVersionReq(">1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from(">=1.2.3"), Err(Error::UnsupportedVersionReq(">=1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from("<1.2.3"), Err(Error::UnsupportedVersionReq("<1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from("<=1.2.3"), Err(Error::UnsupportedVersionReq("<=1.2.3".to_string())));
+        assert_eq!(OrderedVersionReq::try_from("<4.5.6, >1.2.3"), Err(Error::UnsupportedVersionReq("<4.5.6, >1.2.3".to_string()))); // reverse range
+        
+        assert_eq!(OrderedVersionReq::try_from("=1.2.3"), Ok(OrderedVersionReq::try_from("=1.2.3")?));
+        assert_eq!(OrderedVersionReq::try_from(">1.2.3, <4.5.6"), Ok(OrderedVersionReq::try_from(">1.2.3, <4.5.6")?));
+        assert_eq!(OrderedVersionReq::try_from(">=1.2.3, <=4.5.6"), Ok(OrderedVersionReq::try_from(">=1.2.3, <=4.5.6")?));
+        assert_eq!(OrderedVersionReq::try_from("*"), Ok(OrderedVersionReq::try_from("*")?));
+        Ok(())
+    }
+}

--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -11,7 +11,6 @@ use std::ffi::CStr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use once_cell::sync::Lazy;
 use pgrx::guc::{GucContext, GucRegistry, GucSetting};
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::{pg_sys, GucFlags};
@@ -33,21 +32,6 @@ pub(crate) static PLRUST_TRUSTED_PGRX_VERSION: GucSetting<Option<&'static str>> 
         "PLRUST_TRUSTED_PGRX_VERSION",
         "unknown `plrust-trusted-pgrx` version.  `build.rs` must not have run successfully"
     )));
-
-pub(crate) static PLRUST_ALLOWED_DEPENDENCIES_CONTENTS: Lazy<toml::value::Table> =
-    Lazy::new(|| {
-        let path = PathBuf::from_str(
-            &PLRUST_ALLOWED_DEPENDENCIES
-                .get()
-                .expect("plrust.allowed_dependencies is not set in postgresql.conf"),
-        )
-        .expect("plrust.allowed_dependencies is not a valid path");
-
-        let contents =
-            std::fs::read_to_string(&path).expect("Unable to read allow listed dependencies");
-
-        toml::from_str(&contents).expect("Unable to format allow listed dependencies")
-    });
 
 pub(crate) fn init() {
     GucRegistry::define_string_guc(

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -31,6 +31,7 @@ cfg_if::cfg_if! {
     }
 }
 
+mod allow_list;
 mod error;
 mod gucs;
 mod logging;

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -402,20 +402,20 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "yup"]
     fn pgrx_can_panic() {
-        panic!()
+        panic!("yup")
     }
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "yup"]
     fn plrust_can_panic() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION shut_up_and_explode()
             RETURNS text AS
             $$
-                panic!();
+                panic!("yup");
                 Ok(None)
             $$ LANGUAGE plrust;
         "#;
@@ -429,7 +429,7 @@ mod tests {
     #[cfg(feature = "trusted")]
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "Failed to execute command"]
     fn postgrestd_subprocesses_panic() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION say_hello()
@@ -568,7 +568,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "error: usage of an `unsafe` block"]
     fn plrust_block_unsafe_annotated() -> spi::Result<()> {
         // PL/Rust should block creating obvious, correctly-annotated usage of unsafe code
         let definition = r#"
@@ -576,7 +576,7 @@ mod tests {
             RETURNS text AS
             $$
                 use std::{os::raw as ffi, str, ffi::CStr};
-                let int = 0xDEADBEEF;
+                let int:u32 = 0xDEADBEEF;
                 // Note that it is always safe to create a pointer.
                 let ptr = int as *mut u64;
                 // What is unsafe is dereferencing it
@@ -592,7 +592,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "call to unsafe function is unsafe and requires unsafe block"]
     fn plrust_block_unsafe_hidden() -> spi::Result<()> {
         // PL/Rust should not allow hidden injection of unsafe code
         // that may rely on the way PGRX expands into `unsafe fn` to "sneak in"
@@ -601,7 +601,7 @@ mod tests {
             RETURNS text AS
             $$
                 use std::{os::raw as ffi, str, ffi::CStr};
-                let int = 0xDEADBEEF;
+                let int:u32 = 0xDEADBEEF;
                 let ptr = int as *mut u64;
                 ptr.write(0x00_1BADC0DE_00);
                 let cstr = CStr::from_ptr(ptr.cast::<ffi::c_char>());
@@ -613,7 +613,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "error: the `env` and `option_env` macros are forbidden"]
     #[cfg(feature = "trusted")]
     fn plrust_block_env() -> spi::Result<()> {
         let definition = r#"
@@ -627,7 +627,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "error: the `env` and `option_env` macros are forbidden"]
     #[cfg(feature = "trusted")]
     fn plrust_block_option_env() -> spi::Result<()> {
         let definition = r#"
@@ -643,7 +643,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "error: usage of an `unsafe` block"]
     fn plrust_block_unsafe_plutonium() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION super_safe()
@@ -673,7 +673,8 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "xxx"]
+    #[ignore]
     fn plrust_pgloglevel_dont_allcaps_panic() -> spi::Result<()> {
         // This test attempts to annihilate the database.
         // It relies on the existing assumption that tests are run in the same Postgres instance,
@@ -682,9 +683,7 @@ mod tests {
             CREATE FUNCTION dont_allcaps_panic()
             RETURNS text AS
             $$
-                use pgrx::log::{PgLogLevel, elog};
-
-                elog(PgLogLevel::PANIC, "If other tests completed, PL/Rust did not actually destroy the entire database, \
+                ereport!(PANIC, PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, "If other tests completed, PL/Rust did not actually destroy the entire database, \
                                          But if you see this in the error output, something might be wrong.");
                 Ok(Some("lol".into()))
             $$ LANGUAGE plrust;
@@ -797,7 +796,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "parameter name \"a\" used more than once"]
     fn plrust_dup_args() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION not_unique(a int, a int)
@@ -814,7 +813,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "PL/Rust does not support unnamed arguments"]
     fn plrust_defaulting_dup_args() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION not_unique(int, arg0 int)
@@ -831,7 +830,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "plrust functions cannot have their STRICT property altered"]
     fn plrust_cant_change_strict_off() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION cant_change_strict_off()
@@ -840,12 +839,12 @@ mod tests {
             AS $$ Ok(Some(1)) $$;
         "#;
         Spi::run(definition)?;
-        Spi::run("ALTER FUNCTION cant_change_strict() CALLED ON NULL INPUT")
+        Spi::run("ALTER FUNCTION cant_change_strict_off() CALLED ON NULL INPUT")
     }
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic]
+    #[should_panic = "plrust functions cannot have their STRICT property altered"]
     fn plrust_cant_change_strict_on() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION cant_change_strict_on()
@@ -854,7 +853,7 @@ mod tests {
             AS $$ Ok(Some(1)) $$;
         "#;
         Spi::run(definition)?;
-        Spi::run("ALTER FUNCTION cant_change_strict() RETURNS NULL ON NULL INPUT")
+        Spi::run("ALTER FUNCTION cant_change_strict_on() RETURNS NULL ON NULL INPUT")
     }
 
     #[pg_test]
@@ -1372,9 +1371,12 @@ pub mod pg_test {
         let mut allowed_deps = std::fs::File::create(&file_path).unwrap();
         allowed_deps
             .write_all(
-                r#"owo-colors = "3.5.0"
-tokio = { version = "1.19.2", features = ["rt", "net"]}"#
-                    .as_bytes(),
+                r#"
+owo-colors = "=3.5.0"
+tokio = { version = "=1.19.2", features = ["rt", "net"]}
+plutonium = "*"
+"#
+                .as_bytes(),
             )
             .unwrap();
 

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -174,7 +174,6 @@ impl FnCrating {
             }
         };
 
-        pgrx::warning!("Cargo.toml:\n{}", toml::to_string(&cargo_manifest)?);
         Ok(cargo_manifest)
     }
 

--- a/plrust/src/user_crate/crating.rs
+++ b/plrust/src/user_crate/crating.rs
@@ -174,32 +174,7 @@ impl FnCrating {
             }
         };
 
-        match std::env::var("PLRUST_EXPERIMENTAL_CRATES") {
-            Err(_) => (),
-            Ok(path) => {
-                match cargo_manifest
-                    .entry("patch")
-                    .or_insert(toml::Value::Table(Default::default()))
-                    .as_table_mut()
-                    .unwrap() // infallible
-                    .entry("crates-io")
-                {
-                    entry @ toml::map::Entry::Vacant(_) => {
-                        let mut pgrx_table = toml::value::Table::new();
-                        pgrx_table.insert("path".into(), toml::Value::String(path.to_string()));
-                        let mut crates_io_table = toml::value::Table::new();
-                        crates_io_table.insert("pgrx".into(), toml::Value::Table(pgrx_table));
-                        entry.or_insert(toml::Value::Table(crates_io_table));
-                    }
-                    _ => {
-                        return Err(PlRustError::GeneratingCargoToml).wrap_err(
-                            "Setting `[patch]`, already existed (and wasn't expected to)",
-                        )?
-                    }
-                }
-            }
-        };
-
+        pgrx::warning!("Cargo.toml:\n{}", toml::to_string(&cargo_manifest)?);
         Ok(cargo_manifest)
     }
 

--- a/plrust/src/user_crate/mod.rs
+++ b/plrust/src/user_crate/mod.rs
@@ -16,14 +16,15 @@ Consider opening the documentation like so:
 cargo doc --no-deps --document-private-items --open
 ```
 */
+use eyre::WrapErr;
 use std::{path::Path, process::Output};
 
 use pgrx::prelude::PgHeapTuple;
 use pgrx::{pg_sys, PgBuiltInOids, PgOid};
 use proc_macro2::TokenStream;
 use quote::quote;
-use semver;
 
+use crate::allow_list::{load_allowlist, AllowList, Error};
 pub(crate) use build::FnBuild;
 use crate_variant::CrateVariant;
 pub(crate) use crating::FnCrating;
@@ -343,7 +344,12 @@ fn parse_source_and_deps(
 
     code_block.push_str("\n}");
 
-    let user_dependencies = check_user_dependencies(deps_block)?;
+    let mut user_dependencies = validate_user_dependencies(deps_block)?;
+
+    if crate::gucs::PLRUST_ALLOWED_DEPENDENCIES.get().is_some() {
+        let allowlist = load_allowlist().wrap_err("Error loading dependency allow-list")?;
+        user_dependencies = restrict_dependencies(user_dependencies, &allowlist)?;
+    }
 
     let user_code: syn::Block =
         syn::parse_str(&code_block).map_err(PlRustError::ParsingCodeBlock)?;
@@ -352,103 +358,173 @@ fn parse_source_and_deps(
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
-fn check_user_dependencies(user_deps: String) -> eyre::Result<toml::value::Table> {
+fn validate_user_dependencies(user_deps: String) -> eyre::Result<toml::value::Table> {
     let user_dependencies: toml::value::Table = toml::from_str(&user_deps)?;
 
     for (dependency, val) in &user_dependencies {
         match val {
-            toml::Value::String(_) => {
-                // No-op, we currently only support dependencies in the format
-                // foo = "1.0.0"
-            }
+            // user dependencies in these general forms are allowed:
+            //    name = "x.y.z"
+            //    name = { version = "x.y.z", features = [ "a", "b", "c" ]
+            toml::Value::String(_) | toml::Value::Table(_) => {}
+
+            // everything else is unsupported
             _ => {
-                return Err(eyre::eyre!(
-                    "dependency {} with values {:?} is malformatted. Only strings are supported",
-                    dependency,
-                    val
-                ));
+                return Err(eyre::eyre!("dependency `{}` is malformed", dependency));
             }
         }
     }
 
-    check_dependencies_against_allowed(&user_dependencies)?;
     Ok(user_dependencies)
 }
 
+#[derive(thiserror::Error, Debug, PartialEq)]
+enum RestrictionError {
+    #[error("`{0}` is not an allowed dependency")]
+    DependencyNotAllowed(String),
+    #[error("`{0}` does not specify a version")]
+    VersionMissing(String),
+    #[error("`{0}`'s version is not a String type")]
+    NotAString(String),
+    #[error("When specified, the dependency properties of `{1}` for `{0}` must be the same as the restricted set of `{2}`")]
+    DependencyDeclarationMismatch(String, String, String),
+    #[error("Dependency Error: {0}")]
+    DependencyError(crate::allow_list::Error),
+}
+
+impl From<crate::allow_list::Error> for RestrictionError {
+    fn from(value: Error) -> Self {
+        RestrictionError::DependencyError(value)
+    }
+}
+
 #[tracing::instrument(level = "debug", skip_all)]
-fn check_dependencies_against_allowed(dependencies: &toml::value::Table) -> eyre::Result<()> {
-    if matches!(crate::gucs::PLRUST_ALLOWED_DEPENDENCIES.get(), None) {
-        return Ok(());
+fn restrict_dependencies(
+    wanted: toml::value::Table,
+    allowed: &AllowList,
+) -> Result<toml::value::Table, RestrictionError> {
+    fn extract_version<'a>(
+        depname: &str,
+        version_value: &'a toml::value::Value,
+    ) -> Result<&'a str, RestrictionError> {
+        match version_value {
+            toml::value::Value::String(version) => Ok(version),
+            toml::value::Value::Table(table) => table
+                .get("version")
+                .ok_or(RestrictionError::VersionMissing(depname.to_string()))?
+                .as_str()
+                .ok_or(RestrictionError::NotAString(depname.to_string())),
+            _ => panic!("malformed dependency"),
+        }
     }
 
-    let allowed_deps = &*crate::gucs::PLRUST_ALLOWED_DEPENDENCIES_CONTENTS;
-    let mut unsupported_deps = std::vec::Vec::new();
+    let mut actual = toml::value::Table::with_capacity(wanted.len());
+    for (wanted_dep, wanted_value) in &wanted {
+        let allowed_dep = allowed
+            .get(wanted_dep)
+            .ok_or_else(|| RestrictionError::DependencyNotAllowed(wanted_dep.clone()))?;
+        let wanted_version = extract_version(wanted_dep, wanted_value)?;
+        let used = allowed_dep.get_dependency_entry(wanted_version)?;
 
-    for (dep, val) in dependencies {
-        if !allowed_deps.contains_key(dep) {
-            unsupported_deps.push(format!("{} = {}", dep, val.to_string()));
-            continue;
-        }
+        // validate that the other properties that the user might have specified exactly match what
+        // is in the allow-list
+        if let Some(wanted_table) = wanted_value.as_table() {
+            if wanted_table.len() > 1 {
+                let mut wanted = wanted_table.clone();
+                let mut used = used.as_table().unwrap().clone();
 
-        match val {
-            toml::Value::String(ver) => {
-                let req = semver::VersionReq::parse(ver.as_str()).unwrap();
+                // don't compare the version values
+                wanted.remove("version");
+                used.remove("version");
 
-                // Check if the allowed dependency is of format String or toml::Table
-                // foo = "1.0.0" vs foo = { version = "1.0.0", features = ["full", "boo"], test = ["single"]}
-                match allowed_deps.get(dep).unwrap() {
-                    toml::Value::String(allowed_deps_ver) => {
-                        if !req.matches(&semver::Version::parse(allowed_deps_ver)?) {
-                            unsupported_deps.push(format!("{} = {}", dep, val.to_string()));
-                        }
-                    }
-                    toml::Value::Table(allowed_deps_vals) => {
-                        if !req.matches(&semver::Version::parse(
-                            &allowed_deps_vals.get("version").unwrap().as_str().unwrap(),
-                        )?) {
-                            unsupported_deps.push(format!("{} = {}", dep, val.to_string()));
-                        }
-                    }
-                    _ => {
-                        return Err(eyre::eyre!(
-                            "{} contains an unsupported toml format",
-                            crate::gucs::PLRUST_ALLOWED_DEPENDENCIES.get().unwrap()
-                        ));
-                    }
+                if used != wanted {
+                    return Err(RestrictionError::DependencyDeclarationMismatch(
+                        wanted_dep.clone(),
+                        toml::to_string(&wanted).unwrap().trim().replace('\n', ", "),
+                        toml::to_string(&used).unwrap().trim().replace('\n', ", "),
+                    ));
                 }
             }
-            _ => {
-                return Err(eyre::eyre!(
-                    "dependency {} with values {:?} is malformatted. Only strings are supported",
-                    dep,
-                    val
-                ));
-            }
         }
+
+        actual.insert(wanted_dep.clone(), used);
     }
 
-    if !unsupported_deps.is_empty() {
-        return Err(eyre::eyre!(
-            "The following dependencies are unsupported {:?}. The configured PL/Rust only supports {:?}",
-            unsupported_deps,
-            allowed_deps
-        ));
-    }
-
-    Ok(())
+    Ok(actual)
 }
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
+    use crate::allow_list::parse_allowlist;
     use crate::pgproc::ProArgMode;
     use pgrx::*;
     use proc_macro2::{Ident, Span};
     use quote::quote;
     use syn::parse_quote;
+    use toml::toml;
 
     use crate::user_crate::crating::cargo_toml_template;
     use crate::user_crate::*;
+    const TOML: &str = r#"
+a = [ "=1.2.3", "=3.0", ">=6.0.0, <=10", { version = "=2.4.5", features = [ "x", "y", "z" ] }, "*", ">=1.0.0, <5.0.0",">=1.0.0, <2.0.0", ">=2, <=4", "=2.99.99" ]
+b = "*"
+c = "=1.2.3"
+d = { version = "=3.4.5", features = [ "x", "y", "z" ] }
+e = ">=0.8, <0.9"
+    "#;
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_restrict_dependencies() -> eyre::Result<()> {
+        let allowed = parse_allowlist(TOML)?;
+        
+        let restricted = restrict_dependencies(toml! { a = "3.0" }, &allowed)?;
+        assert_eq!(toml! { a = { version = "=3.0" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { a = { version = "2.4.5", features = [ "q", "r", "p" ], default-features = false } }, &allowed);
+        if !matches!(restricted, Err(RestrictionError::DependencyDeclarationMismatch(..))) {
+            panic!("got valid restricted table when we shouldn't have");
+        }
+
+        let restricted = restrict_dependencies(toml! { a = { version = "2.4.5", features = [ "x", "y", "z" ] } }, &allowed)?;
+        assert_eq!(toml! { a = { version = "=2.4.5", features = [ "x", "y", "z" ] } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { a = { version = "2.4.5" } }, &allowed)?;
+        assert_eq!(toml! { a = { version = "=2.4.5", features = [ "x", "y", "z" ] } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { a = { version = "6.7.8" } }, &allowed)?;
+        assert_eq!(toml! { a = { version = "=6.7.8" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { a = { version = "=6.7.8" } }, &allowed)?;
+        assert_eq!(toml! { a = { version = "=6.7.8" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { a = "*" }, &allowed)?;
+        assert_eq!(toml! { a = { version = ">=6.0.0, <=10" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { b = "=1.2.3" } , &allowed)?;
+        assert_eq!(toml! { b = { version = "=1.2.3" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { b = "42" } , &allowed)?;
+        assert_eq!(toml! { b = { version = "^42" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { c = "1.2.3" } , &allowed)?;
+        assert_eq!(toml! { c = { version = "=1.2.3" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { c = "*" } , &allowed)?;
+        assert_eq!(toml! { c = { version = "=1.2.3" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { c = "99" } , &allowed);
+        assert_eq!(restricted, Err(RestrictionError::DependencyError(Error::VersionNotPermitted("99".to_string()))));
+
+        let restricted = restrict_dependencies(toml! { e = "0.8" } , &allowed)?;
+        assert_eq!(toml! { e = { version = ">=0.8, <0.9" } }, restricted);
+
+        let restricted = restrict_dependencies(toml! { e = "0.9" } , &allowed);
+        assert_eq!(restricted, Err(RestrictionError::DependencyError(Error::VersionNotPermitted("0.9".to_string()))));
+
+        Ok(())
+    }
 
     #[pg_test]
     fn full_workflow() {


### PR DESCRIPTION
Generally, the changes here allow a single dependency in the allow-list to have one **or more** versions specified, either as exact (`=`) or bounded ranges (`>=,<=`) or wildcards (`*`).

PL/Rust will pick the largest (newest, hopefully) entry from the allow-list that matches the function's requested version.  Depending on how either is written, the allow-list version could be used or the requested version could be used.

See the new documentation for more details.

---

As a drive-by, a number of our unit tests were tagged with `#[should_panic]` but without an expected message.  Turns out many of them were panicking but for the wrong reason!  This PR addresses these too.  

That said, the `plrust_pgloglevel_dont_allcaps_panic` test is currently set to `#[ignore]`.  Its intent is to block using Postgres' `PANIC` log level (which purposely crashes the backend), and I'm not yet clear on how this is supposed to be addressed.