### PR TITLE
Improve plrustc lint messages 

### DIFF
--- a/plrustc/plrustc/src/lints/builtin_macros.rs
+++ b/plrustc/plrustc/src/lints/builtin_macros.rs
@@ -19,7 +19,7 @@ impl PlrustBuiltinMacros {
     fn lint_fs(&self, cx: &LateContext<'_>, sp: Span) {
         cx.lint(
             PLRUST_FILESYSTEM_MACROS,
-            "the `include_str`, `include_bytes`, and `include` macros are forbidden",
+            "the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust",
             |b| b.set_span(sp),
         );
     }

--- a/plrustc/plrustc/src/lints/extern_blocks.rs
+++ b/plrustc/plrustc/src/lints/extern_blocks.rs
@@ -14,7 +14,7 @@ impl<'tcx> LateLintPass<'tcx> for NoExternBlockPass {
             // TODO: Do we need to allow ones from macros from pgrx?
             cx.lint(
                 PLRUST_EXTERN_BLOCKS,
-                "`extern` blocks are not allowed",
+                "`extern` blocks are not allowed in PL/Rust",
                 |b| b.set_span(item.span),
             )
         }

--- a/plrustc/plrustc/src/lints/lifetime_param_trait.rs
+++ b/plrustc/plrustc/src/lints/lifetime_param_trait.rs
@@ -15,7 +15,7 @@ impl<'tcx> LateLintPass<'tcx> for LifetimeParamTraitPass {
                 if let hir::GenericParamKind::Lifetime { .. } = param.kind {
                     cx.lint(
                         PLRUST_LIFETIME_PARAMETERIZED_TRAITS,
-                        "Trait is parameterize by lifetime.",
+                        "PL/Rust forbids declaring traits with generic lifetime parameters",
                         |b| b.set_span(item.span),
                     )
                 }

--- a/plrustc/plrustc/src/lints/print_macros.rs
+++ b/plrustc/plrustc/src/lints/print_macros.rs
@@ -27,7 +27,8 @@ impl PlrustPrintMacros {
     fn fire(&self, cx: &LateContext<'_>, span: Span) {
         cx.lint(
             PLRUST_PRINT_MACROS,
-            "the printing macros are forbidden, consider using `log!()` instead",
+            "the printing macros are forbidden in PL/Rust, \
+            consider using `pgrx::log!()` instead",
             |b| b.set_span(span),
         );
     }

--- a/plrustc/plrustc/src/lints/static_impls.rs
+++ b/plrustc/plrustc/src/lints/static_impls.rs
@@ -16,7 +16,8 @@ impl<'tcx> LateLintPass<'tcx> for PlrustStaticImpls {
         if self.has_static(imp.self_ty) {
             cx.lint(
                 PLRUST_STATIC_IMPLS,
-                "`impl` blocks for types containing `'static` references are not allowed",
+                "`impl` blocks for types containing `'static` references \
+                are not allowed in PL/Rust",
                 |b| b.set_span(imp.self_ty.span),
             )
         }

--- a/plrustc/plrustc/src/lints/stdio.rs
+++ b/plrustc/plrustc/src/lints/stdio.rs
@@ -19,7 +19,8 @@ impl<'tcx> LateLintPass<'tcx> for PlrustPrintFunctions {
             if super::utils::does_expr_call_path(cx, expr, path) {
                 cx.lint(
                     PLRUST_STDIO,
-                    "the standard streams are forbidden, consider using `log!()` instead",
+                    "the standard streams are forbidden in PL/Rust, \
+                    consider using `pgrx::log!()` instead",
                     |b| b.set_span(expr.span),
                 );
             }

--- a/plrustc/plrustc/src/lints/sus_trait_object.rs
+++ b/plrustc/plrustc/src/lints/sus_trait_object.rs
@@ -30,7 +30,7 @@ impl<'tcx> LateLintPass<'tcx> for PlrustSuspiciousTraitObject {
                 if let hir::TyKind::TraitObject(..) = &ty.kind {
                     cx.lint(
                         PLRUST_SUSPICIOUS_TRAIT_OBJECT,
-                        "trait objects in turbofish are forbidden",
+                        "using trait objects in turbofish position is forbidden by PL/Rust",
                         |b| b.set_span(expr.span),
                     );
                 }

--- a/plrustc/plrustc/uitests/extern_block.stderr
+++ b/plrustc/plrustc/uitests/extern_block.stderr
@@ -1,4 +1,4 @@
-error: `extern` blocks are not allowed
+error: `extern` blocks are not allowed in PL/Rust
   --> $DIR/extern_block.rs:2:1
    |
 LL | extern "C" {}
@@ -6,19 +6,19 @@ LL | extern "C" {}
    |
    = note: `-F plrust-extern-blocks` implied by `-F plrust-lints`
 
-error: `extern` blocks are not allowed
+error: `extern` blocks are not allowed in PL/Rust
   --> $DIR/extern_block.rs:3:1
    |
 LL | extern "Rust" {}
    | ^^^^^^^^^^^^^^^^
 
-error: `extern` blocks are not allowed
+error: `extern` blocks are not allowed in PL/Rust
   --> $DIR/extern_block.rs:5:1
    |
 LL | extern {}
    | ^^^^^^^^^
 
-error: `extern` blocks are not allowed
+error: `extern` blocks are not allowed in PL/Rust
   --> $DIR/extern_block.rs:9:9
    |
 LL |         extern "C" {}

--- a/plrustc/plrustc/uitests/fs_macros.stderr
+++ b/plrustc/plrustc/uitests/fs_macros.stderr
@@ -1,4 +1,4 @@
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:3:18
    |
 LL | const _A: &str = include_str!("fs_macros_included_file.txt");
@@ -6,73 +6,73 @@ LL | const _A: &str = include_str!("fs_macros_included_file.txt");
    |
    = note: `-F plrust-filesystem-macros` implied by `-F plrust-lints`
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:5:19
    |
 LL | const _B: &[u8] = include_bytes!("fs_macros_included_file.txt");
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:7:18
    |
 LL | const _C: &str = core::include_str!("fs_macros_included_file.txt");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:8:19
    |
 LL | const _D: &[u8] = core::include_bytes!("fs_macros_included_file.txt");
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:16:18
    |
 LL | const _E: &str = indirect!(include_str);
    |                  ^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:17:19
    |
 LL | const _F: &[u8] = indirect!(include_bytes);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:31:18
    |
 LL | const _G: &str = in_macro!();
    |                  ^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:32:28
    |
 LL | const _H: &str = in_macro!(include_str!("fs_macros_included_file.txt"));
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:33:29
    |
 LL | const _I: &[u8] = in_macro!(include_bytes!("fs_macros_included_file.txt"));
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:34:19
    |
 LL | const _J: &[u8] = in_macro!(include_bytes, "fs_macros_included_file.txt");
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:37:18
    |
 LL | const _L: &str = sneaky!("fs_macros_included_file.txt");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:38:18
    |
 LL | const _M: &str = in_macro!(sneaky, "fs_macros_included_file.txt");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the `include_str`, `include_bytes`, and `include` macros are forbidden
+error: the `include_str`, `include_bytes`, and `include` macros are forbidden in PL/Rust
   --> $DIR/fs_macros.rs:41:21
    |
 LL |     format!("{:?}", in_macro!())

--- a/plrustc/plrustc/uitests/lifetime_trait.stderr
+++ b/plrustc/plrustc/uitests/lifetime_trait.stderr
@@ -1,4 +1,4 @@
-error: Trait is parameterize by lifetime.
+error: PL/Rust forbids declaring traits with generic lifetime parameters
   --> $DIR/lifetime_trait.rs:3:1
    |
 LL | trait Foo<'a> {}
@@ -6,7 +6,7 @@ LL | trait Foo<'a> {}
    |
    = note: `-F plrust-lifetime-parameterized-traits` implied by `-F plrust-lints`
 
-error: Trait is parameterize by lifetime.
+error: PL/Rust forbids declaring traits with generic lifetime parameters
   --> $DIR/lifetime_trait.rs:9:9
    |
 LL |         trait Foobar<'a> {}

--- a/plrustc/plrustc/uitests/print_macros.stderr
+++ b/plrustc/plrustc/uitests/print_macros.stderr
@@ -1,4 +1,4 @@
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:4:5
    |
 LL |     print!("hello");
@@ -6,61 +6,61 @@ LL |     print!("hello");
    |
    = note: `-F plrust-print-macros` implied by `-F plrust-lints`
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:5:5
    |
 LL |     println!("world");
    |     ^^^^^^^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:7:5
    |
 LL |     eprint!("test");
    |     ^^^^^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:8:5
    |
 LL |     eprintln!("123");
    |     ^^^^^^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:10:5
    |
 LL |     dbg!("baz");
    |     ^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:15:5
    |
 LL |     p!("hello");
    |     ^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:16:5
    |
 LL |     pln!("world");
    |     ^^^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:18:5
    |
 LL |     e!("test");
    |     ^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:19:5
    |
 LL |     eln!("123");
    |     ^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:21:5
    |
 LL |     d!("baz");
    |     ^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:26:9
    |
 LL |         print!("hello");
@@ -71,7 +71,7 @@ LL |     wrapped!();
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:27:9
    |
 LL |         println!("world");
@@ -82,7 +82,7 @@ LL |     wrapped!();
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:29:9
    |
 LL |         eprint!("test");
@@ -93,7 +93,7 @@ LL |     wrapped!();
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:30:9
    |
 LL |         eprintln!("123");
@@ -104,7 +104,7 @@ LL |     wrapped!();
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:32:9
    |
 LL |         dbg!("baz");
@@ -115,13 +115,13 @@ LL |     wrapped!();
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:53:15
    |
 LL |     indirect!(println!("foo"));
    |               ^^^^^^^^^^^^^^^
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:45:9
    |
 LL |         $mac!($arg)
@@ -132,7 +132,7 @@ LL |     indirect!(println, "foo");
    |
    = note: this error originates in the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:26:9
    |
 LL |         print!("hello");
@@ -143,7 +143,7 @@ LL |     indirect!(wrapped!());
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:27:9
    |
 LL |         println!("world");
@@ -154,7 +154,7 @@ LL |     indirect!(wrapped!());
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:29:9
    |
 LL |         eprint!("test");
@@ -165,7 +165,7 @@ LL |     indirect!(wrapped!());
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:30:9
    |
 LL |         eprintln!("123");
@@ -176,7 +176,7 @@ LL |     indirect!(wrapped!());
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:32:9
    |
 LL |         dbg!("baz");
@@ -187,7 +187,7 @@ LL |     indirect!(wrapped!());
    |
    = note: this error originates in the macro `wrapped` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:26:9
    |
 LL |         print!("hello");
@@ -198,7 +198,7 @@ LL |     indirect!(@call wrapped);
    |
    = note: this error originates in the macro `wrapped` which comes from the expansion of the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:27:9
    |
 LL |         println!("world");
@@ -209,7 +209,7 @@ LL |     indirect!(@call wrapped);
    |
    = note: this error originates in the macro `wrapped` which comes from the expansion of the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:29:9
    |
 LL |         eprint!("test");
@@ -220,7 +220,7 @@ LL |     indirect!(@call wrapped);
    |
    = note: this error originates in the macro `wrapped` which comes from the expansion of the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:30:9
    |
 LL |         eprintln!("123");
@@ -231,7 +231,7 @@ LL |     indirect!(@call wrapped);
    |
    = note: this error originates in the macro `wrapped` which comes from the expansion of the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: the printing macros are forbidden, consider using `log!()` instead
+error: the printing macros are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/print_macros.rs:32:9
    |
 LL |         dbg!("baz");

--- a/plrustc/plrustc/uitests/static_impl_etc.stderr
+++ b/plrustc/plrustc/uitests/static_impl_etc.stderr
@@ -1,4 +1,4 @@
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:8:17
    |
 LL | impl<T> Foo for &'static T {}
@@ -6,61 +6,61 @@ LL | impl<T> Foo for &'static T {}
    |
    = note: `-F plrust-static-impls` implied by `-F plrust-lints`
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:9:17
    |
 LL | impl<T> Foo for &'static mut T {}
    |                 ^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:10:17
    |
 LL | impl<T> Foo for [&'static T] {}
    |                 ^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:11:17
    |
 LL | impl<T> Foo for &[&'static T] {}
    |                 ^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:12:17
    |
 LL | impl<T> Foo for (i32, [&'static T]) {}
    |                 ^^^^^^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:13:17
    |
 LL | impl<T> Foo for (i32, [&'static T; 1]) {}
    |                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:14:17
    |
 LL | impl<T> Foo for *const &'static T {}
    |                 ^^^^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:15:17
    |
 LL | impl<T> Foo for Bar<i32, &'static T> {}
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:16:17
    |
 LL | impl<T> Foo for Baz<'static, T> {}
    |                 ^^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:17:17
    |
 LL | impl<T> Foo for dyn Quux<&'static T> {}
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_etc.rs:18:17
    |
 LL | impl<T> Foo for &'static dyn Quux<T> {}

--- a/plrustc/plrustc/uitests/static_impl_unsound.stderr
+++ b/plrustc/plrustc/uitests/static_impl_unsound.stderr
@@ -1,4 +1,4 @@
-error: `impl` blocks for types containing `'static` references are not allowed
+error: `impl` blocks for types containing `'static` references are not allowed in PL/Rust
   --> $DIR/static_impl_unsound.rs:11:34
    |
 LL | impl<T: Display> Displayable for (T, Box<Option<&'static T>>) {

--- a/plrustc/plrustc/uitests/stdio.stderr
+++ b/plrustc/plrustc/uitests/stdio.stderr
@@ -1,4 +1,4 @@
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:4:16
    |
 LL |     let _out = std::io::stdout();
@@ -6,43 +6,43 @@ LL |     let _out = std::io::stdout();
    |
    = note: `-F plrust-stdio` implied by `-F plrust-lints`
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:5:15
    |
 LL |     let _in = std::io::stdin();
    |               ^^^^^^^^^^^^^^
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:6:16
    |
 LL |     let _err = std::io::stderr();
    |                ^^^^^^^^^^^^^^^
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:11:16
    |
 LL |     let _out = stdout();
    |                ^^^^^^
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:12:15
    |
 LL |     let _in = stdin();
    |               ^^^^^
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:13:16
    |
 LL |     let _err = stderr();
    |                ^^^^^^
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:18:28
    |
 LL |     let _still_forbidden = renamed();
    |                            ^^^^^^^
 
-error: the standard streams are forbidden, consider using `log!()` instead
+error: the standard streams are forbidden in PL/Rust, consider using `pgrx::log!()` instead
   --> $DIR/stdio.rs:22:19
    |
 LL |     let as_func = std::io::stdout;

--- a/plrustc/plrustc/uitests/sus_trait_obj_transmute.stderr
+++ b/plrustc/plrustc/uitests/sus_trait_obj_transmute.stderr
@@ -1,4 +1,4 @@
-error: trait objects in turbofish are forbidden
+error: using trait objects in turbofish position is forbidden by PL/Rust
   --> $DIR/sus_trait_obj_transmute.rs:16:5
    |
 LL |     foo::<dyn Object<U, Output = T>, U>(x)


### PR DESCRIPTION
- Fix typos.
- Make it clear that they're PL/Rust restrictions.