### PR TITLE
Fully resolve aliases in plrust-suspicious-trait-object

### DIFF
--- a/plrustc/plrustc/src/lints/sus_trait_object.rs
+++ b/plrustc/plrustc/src/lints/sus_trait_object.rs
@@ -1,5 +1,7 @@
+use hir::def::{DefKind, Res};
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty;
 
 declare_plrust_lint!(
     pub(crate) PLRUST_SUSPICIOUS_TRAIT_OBJECT,
@@ -27,7 +29,29 @@ impl<'tcx> LateLintPass<'tcx> for PlrustSuspiciousTraitObject {
                 let hir::GenericArg::Type(ty) = arg else {
                     continue;
                 };
-                if let hir::TyKind::TraitObject(..) = &ty.kind {
+                let is_trait_obj = match &ty.kind {
+                    hir::TyKind::TraitObject(..) => true,
+                    hir::TyKind::Path(qpath) => {
+                        let res = cx.qpath_res(qpath, ty.hir_id);
+                        let did = match res {
+                            Res::Def(DefKind::TyAlias | DefKind::AssocTy, def_id) => def_id,
+                            Res::SelfTyAlias { alias_to, .. } => alias_to,
+                            _ => continue,
+                        };
+                        let binder = cx.tcx.type_of(did);
+                        let ty = binder.subst_identity();
+                        if matches!(ty.kind(), ty::TyKind::Dynamic(..)) {
+                            true
+                        } else {
+                            match cx.tcx.try_normalize_erasing_regions(cx.param_env, ty) {
+                                Ok(t) => matches!(t.kind(), ty::TyKind::Dynamic(..)),
+                                _ => false,
+                            }
+                        }
+                    }
+                    _ => false,
+                };
+                if is_trait_obj {
                     cx.lint(
                         PLRUST_SUSPICIOUS_TRAIT_OBJECT,
                         "using trait objects in turbofish position is forbidden by PL/Rust",

--- a/plrustc/plrustc/uitests/sus_trait_obj_alias.rs
+++ b/plrustc/plrustc/uitests/sus_trait_obj_alias.rs
@@ -1,0 +1,28 @@
+#![crate_type = "lib"]
+trait Object {
+    type Output;
+}
+
+impl<T: ?Sized> Object for T {
+    type Output = &'static u64;
+}
+
+fn foo<'a, T: ?Sized>(x: <T as Object>::Output) -> &'a u64 {
+    x
+}
+
+fn transmute_lifetime<'a, 'b>(x: &'a u64) -> &'b u64 {
+    type A<'x> = dyn Object<Output = &'x u64>;
+    type B<'x> = A<'x>;
+    foo::<B<'a>>(x)
+}
+
+// And yes this is a genuine `transmute_lifetime`!
+fn get_dangling<'a>() -> &'a u64 {
+    let x = 0;
+    transmute_lifetime(&x)
+}
+
+pub fn problems() -> &'static u64 {
+    get_dangling()
+}

--- a/plrustc/plrustc/uitests/sus_trait_obj_alias.stderr
+++ b/plrustc/plrustc/uitests/sus_trait_obj_alias.stderr
@@ -1,0 +1,10 @@
+error: using trait objects in turbofish position is forbidden by PL/Rust
+  --> $DIR/sus_trait_obj_alias.rs:17:5
+   |
+LL |     foo::<B<'a>>(x)
+   |     ^^^^^^^^^^^^
+   |
+   = note: `-F plrust-suspicious-trait-object` implied by `-F plrust-lints`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
What a hassle. The other lints aren't sensitive to this but just by coincidence -- using aliases in them causes the I-unsound Rust issue to resolve itself. I'll see if I can figure out a less error-prone way to do those.