### PR TITLE
prepare-v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plrust"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "base64",
  "cfg-if",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "plrust-trusted-pgrx"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "pgrx",
 ]

--- a/doc/src/config-pg.md
+++ b/doc/src/config-pg.md
@@ -69,7 +69,7 @@ compiling user functions. This typically should not need to be manually set.
 
 
 ```bash
-plrust.trusted_pgrx_version = '1.1.3'
+plrust.trusted_pgrx_version = '1.2.0'
 ```
 
 

--- a/plrust-trusted-pgrx/Cargo.toml
+++ b/plrust-trusted-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust-trusted-pgrx"
-version = "1.1.3"
+version = "1.2.0"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust"
-version = "1.1.3"
+version = "1.2.0"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL Open Source License"

--- a/plrustc/Cargo.lock
+++ b/plrustc/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "plrustc"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "compiletest_rs",
  "libc",

--- a/plrustc/plrustc/Cargo.toml
+++ b/plrustc/plrustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrustc"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 description = "`rustc_driver` wrapper for plrust"
 license = "PostgreSQL"


### PR DESCRIPTION
PL/Rust v1.2.0 is a brings a number of new features.  It is backwards compatible with all existing `LANGUAGE plrust` functions, both the source and compiled forms.

# What's Changed

## More Data Type Support

### Date/Time/Interval

* Date/time/interval support by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/316

PL/Rust v1.2.0 now supports Postgres `date`, `time`, `time with time zone`, `timestamp`, `timestamp with time zone`, and `interval` types as both function arguments and return types.

These types map to similarly named Rust types via `plrust-trusted-pgrx` and are fairly feature complete.  Please see the [data types](https://tcdi.github.io/plrust/data-types.html) documentation for their mappings.

* Expose various date/time functions from pgrx by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/316

PL/Rust now exposes Postgres' various date/time construction functions such as `now()`, `current_timestamp()`, and many more.  They're documented in the [plrust-trusted-pgx API documentation](https://docs.rs/plrust-trusted-pgrx/1.1.3/plrust_trusted_pgrx/datum/index.html).

### Arrays as Slices

Function arguments which are arrays of primitive types (ie, `Array<i32 | i64 | f32 | f64>`) now have an `as_slice()` method, providing direct read-only access to the array contents as a `&[i32 | i64 | f32 | f64]`.  This can greatly improve performance when iterating or doing random access with these types of arrays.

The [arrays chapter](https://tcdi.github.io/plrust/data-types/arrays.html)  provides some examples.

### Set Returning Functions

* Support `RETURNS TABLE (...)` functions by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/326

PL/Rust now supports `RETURNS TABLE (...)`, allowing `LANGUAGE plrust` functions to return wide rows of disparate data.  

A user function returns a `TableIterator` whose's item is a Rust tuple of values matching the data types declared in the `RETURNS TABLE (...)` clause.  PL/Rust takes care of the rest!

### User Defined Types Support

PL/Rust now supports working with composite types created in SQL via the `CREATE TABLE ... AS (...)` statement.  These types can be used as both function arguments and return types.  They can be constructed, by name, in PL/Rust functions, and have their attributes are accessible and mutable.  This happened in PR #311.

The documentation, with a detailed example is in the new [UDTs chapter](https://tcdi.github.io/plrust/data-types/udts.html)

## Dependency Allow List Changes

* In response to issue #325, rework the dependency allow-list. by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/332

The dependency allow-list has been redesigned to allow much more flexibility in defining dependencies, the specific versions (or version ranges) allowed, and any other dependency related properties such as features.

Remember that by default PL/Rust allows **all** 3rd party crates.  It is recommended to configure an allow-list.  The allow-list is documented [here](https://tcdi.github.io/plrust/dependencies.html).

## Lints

v1.2.0 adds another lint to guard against potential "I-Unsound" bugs in the Rust compiler and also does some cleanup along the way.

* Add a lint for the Self tuple struct soundness hole by @thomcc in https://github.com/tcdi/plrust/pull/320
* Fully resolve aliases in plrust-suspicious-trait-object by @thomcc in https://github.com/tcdi/plrust/pull/335
* Remove the `unaligned_references` lint (it's now a compiler error) by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/328
* Improve plrustc lint messages  by @thomcc in https://github.com/tcdi/plrust/pull/333
* Don't require a loaded function to have "compile lints" applied. by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/327

This last one (#327) allows existing compiled PL/Rust functions to be loaded by new PL/Rust versions that now have lints the previous version didn't.

## Trusted Support on MacOS

PL/Rust v1.2.0 can now be used as a trusted language handler on MacOS!  

Previous versions could be compiled/installed on MacOS but not in the trusted form.  Most of the work for this happened by @thomcc in the `postgrestd` library.

* Support `--features trusted` on macOS by @eeeebbbbrrrr in https://github.com/tcdi/plrust/pull/334


## Operational Changes

* Bump versions to 1.70.0  by @thomcc in https://github.com/tcdi/plrust/pull/321

PL/Rust now **requires** rust v1.70.0.  In order to compile and install PL/Rust v1.2.0 you'll first need to update to exactly rust v1.70.0.

## Project Management

* Various updates to CI by @BradyBonnette in https://github.com/tcdi/plrust/pull/331

Our CI is nearly 2x faster now and also includes testing on MacOS.

# Upgrading

Upgrading to PL/Rust v1.2.0 is as simple as installing the new `plrust.so`.  If you're using our pre-built .deb packages, simply install them with `dpkg` and restart the Postgres cluster.  

If you've installed PL/Rust manually, simply follow that process again, making sure to compile the new `postgrestd` and `plrustc` crates, both with Rust 1.70.0.



**Full Changelog**: https://github.com/tcdi/plrust/compare/v1.1.3...v1.2.0