### PR TITLE
Expose various date/time functions from pgrx

### DIFF
--- a/plrust-trusted-pgrx/src/lib.rs
+++ b/plrust-trusted-pgrx/src/lib.rs
@@ -24,8 +24,10 @@ pub mod datum {
 
     // dates & times
     pub use ::pgrx::datum::{
-        Date, DateTimeConversionError, DateTimeParts, HasExtractableParts, Interval, Time,
-        TimeWithTimeZone, Timestamp, TimestampWithTimeZone,
+        clock_timestamp, current_date, current_time, current_timestamp, local_timestamp, now,
+        statement_timestamp, time_of_day, to_timestamp, transaction_timestamp, Date,
+        DateTimeConversionError, DateTimeParts, HasExtractableParts, Interval, Time,
+        TimeWithTimeZone, Timestamp, TimestampPrecision, TimestampWithTimeZone,
     };
 
     // zero-copy Arrays

--- a/plrust-trusted-pgrx/src/lib.rs
+++ b/plrust-trusted-pgrx/src/lib.rs
@@ -24,10 +24,10 @@ pub mod datum {
 
     // dates & times
     pub use ::pgrx::datum::{
-        clock_timestamp, current_date, current_time, current_timestamp, local_timestamp, now,
-        statement_timestamp, time_of_day, to_timestamp, transaction_timestamp, Date,
-        DateTimeConversionError, DateTimeParts, HasExtractableParts, Interval,
-        IntervalConversionError, Time, TimeWithTimeZone, Timestamp, TimestampPrecision,
+        clock_timestamp, current_date, current_time, current_timestamp, get_timezone_offset,
+        local_timestamp, now, statement_timestamp, time_of_day, to_timestamp,
+        transaction_timestamp, Date, DateTimeConversionError, DateTimeParts, HasExtractableParts,
+        Interval, IntervalConversionError, Time, TimeWithTimeZone, Timestamp, TimestampPrecision,
         TimestampWithTimeZone, ToIsoString,
     };
 

--- a/plrust-trusted-pgrx/src/lib.rs
+++ b/plrust-trusted-pgrx/src/lib.rs
@@ -26,8 +26,9 @@ pub mod datum {
     pub use ::pgrx::datum::{
         clock_timestamp, current_date, current_time, current_timestamp, local_timestamp, now,
         statement_timestamp, time_of_day, to_timestamp, transaction_timestamp, Date,
-        DateTimeConversionError, DateTimeParts, HasExtractableParts, Interval, Time,
-        TimeWithTimeZone, Timestamp, TimestampPrecision, TimestampWithTimeZone,
+        DateTimeConversionError, DateTimeParts, HasExtractableParts, Interval,
+        IntervalConversionError, Time, TimeWithTimeZone, Timestamp, TimestampPrecision,
+        TimestampWithTimeZone, ToIsoString,
     };
 
     // zero-copy Arrays


### PR DESCRIPTION
These functions provide accessors, generally, for Postgres' various representations of the "current time".  `now()` is probably the most common of these.

Also adds a couple of missing traits and types from pgrx' "datetime_support" module.