### PR TITLE
correct docs and code comments around the `plrust.required_lints` GUC

### DIFF
--- a/doc/src/config-lints.md
+++ b/doc/src/config-lints.md
@@ -12,11 +12,14 @@ these custom lints, PL/Rust uses some standard Rust lints to enforce safety.
 
 
 The `plrust.required_lints` GUC defines which lints must have been applied to a function before PL/Rust will load the
-library and execute the function.  Using the `PLRUST_REQUIRED_LINTS` environment variable, it is possible to enforce
-that certain lints are always required of compiled functions, regardless of the `plrust.required_lints` GUC value.
-`PLRUST_REQUIRED_LINTS`'s format is a comma-separated list of lint named.  It must be set in the environment in which 
-Postgres is started.  The intention here is that the system administrator can force certain lints for execution if for 
-some reason `postgresql.conf` or the users able to modify it are not trusted.
+library and execute the function.  The default value is the empty set -- PL/Rust will not require any specific lints to
+have been previously applied to a function.
+
+Using the `PLRUST_REQUIRED_LINTS` environment variable, it is possible to enforce that certain lints are always required
+of compiled functions, regardless of the `plrust.required_lints` GUC value.`PLRUST_REQUIRED_LINTS`'s format is a
+comma-separated list of lint named.  It must be set in the environment in which Postgres is started.  The intention here
+is that the system administrator can force certain lints for execution if for some reason `postgresql.conf` or the users
+able to modify it are not trusted.
 
 
 In all cases, these lints are added to the generated code which wraps the user's `LANGUAGE plrust` function, as 

--- a/doc/src/config-pg.md
+++ b/doc/src/config-pg.md
@@ -164,5 +164,4 @@ plrust.compile_lints = 'plrust_extern_blocks, plrust_lifetime_parameterized_trai
 
 A comma-separated list of Rust lints that are required to have been applied to a user function before PL/Rust will load the library and execute the function.
 
-The value of `plrust.required_lints` defaults to `plrust.compile_lints`.
 

--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -91,7 +91,7 @@ pub(crate) fn init() {
     GucRegistry::define_string_guc(
         "plrust.required_lints",
         "A comma-separated list of Rust code lints that are required to have been applied to a PL/Rust user function before PL/Rust will execute it",
-        "If unspecified, PL/Rust will use a set of defaults",
+        "If unspecified, the default is the empty set",
         &PLRUST_REQUIRED_LINTS,
         GucContext::Sighup,
         GucFlags::default(),

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -13,16 +13,15 @@ Use of this source code is governed by the PostgreSQL license that can be found 
 #[cfg(all(
     feature = "trusted",
     not(any(
-            all(
-                target_os = "linux",
-                any(target_arch = "x86_64", target_arch = "aarch64")
-            ),
-            all(
-                target_os = "macos",
-                any(target_arch = "x86_64", target_arch = "aarch64")
-            )
+        all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ),
+        all(
+            target_os = "macos",
+            any(target_arch = "x86_64", target_arch = "aarch64")
         )
-    )
+    ))
 ))]
 compile_error!("This platform does not support the 'trusted' version of plrust");
 
@@ -76,8 +75,7 @@ $$;
     bootstrap
 );
 
-/// This is the default set of lints we apply to PL/Rust user functions, and require of PL/Rust user
-/// functions before we'll load and execute them.
+/// This is the default set of lints we apply to PL/Rust user functions during compilation.
 ///
 /// The defaults **can** be changed with the `plrust.compile_lints` and `plrust.required_lints` GUCS
 // Hello from the futurepast!


### PR DESCRIPTION
This just fixes some inaccuracies in the docs and code comments that were missed when we changed how `plrust.required_lints` is applied in #327