### PR TITLE
Feike/toolchain fix

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -6,4 +6,4 @@ src = "src"
 title = "PL/Rust Guide"
 
 [preprocessor.variables.variables]
-toolchain_ver = "1.67.1"
+toolchain_ver = "1.70.0"

--- a/doc/src/install-prerequisites.md
+++ b/doc/src/install-prerequisites.md
@@ -111,7 +111,7 @@ rustc -V
 The output from `rustc -V` should look similar to the following example.
 
 ```
-rustc {{toolchain_ver}} (d5a82bbd2 2023-02-07)
+rustc {{toolchain_ver}} (90c541806 2023-05-31)
 ```
 
 Use `rustup default` to check that the explicit version of `rustc` is


### PR DESCRIPTION
In commit 4f71dd52 the default version is bumped to 1.70.0, yet these
instructions still carry the old version.
Using 1.67.1 fails using the current latest release tag, wherease 1.70.0
succeeds.
