### PR TITLE
Support Postgres 16beta2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,165 +20,165 @@ jobs:
   # The image created for running these tasks already have a majority of the dependencies installed, such as system
   # libraries, sccache, github runners, rust, etc. This is to cut back on the amount of time it takes to launch a runner.
   # If something is missing, it can be added here or baked into a new image outside of Github Actions.
-  # plrust_arm64_amzn2:
-  #   name: aarch64 tests (amzn2)
-  #   runs-on: [self-hosted, linux, ARM64, launch_template_id__lt-0013395587950cb5d]
-  #   defaults:
-  #     run:
-  #       shell: bash
+  plrust_arm64_amzn2:
+    name: aarch64 tests (amzn2)
+    runs-on: [self-hosted, linux, ARM64, launch_template_id__lt-0013395587950cb5d]
+    defaults:
+      run:
+        shell: bash
 
-  #   strategy:
-  #     matrix:
-  #       version: ["pg13", "pg14", "pg15", "pg16"]
-  #       target: ["host", "postgrestd"]
-  #     fail-fast: false
+    strategy:
+      matrix:
+        version: ["pg13", "pg14", "pg15", "pg16"]
+        target: ["host", "postgrestd"]
+      fail-fast: false
 
-  #   # Note about environment variables: Even though a majority of these environment variables are baked into the runner image,
-  #   # Github Actions seemingly runs self-hosted tasks in a different manner such that even baken-in environment variables are
-  #   # removed. Howevever, they can be declared here and persist through all tasks. Assume that the home directory for the
-  #   # runner is /home/ec2-user
-  #   env:
-  #     AWS_CACHE_BUCKET: tcdi-ci-plrust-build-cache.private
-  #     CACHE_KEY_VERSION: v0
-  #     CI: true
-  #     PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/ec2-user/actions-runner/_work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
-  #     RUSTUP_HOME: /home/ec2-user/.rustup
-  #     RUSTC_WRAPPER: sccache
-  #     RUSTFLAGS: -Copt-level=0 -Dwarnings
-  #     SCCACHE_BIN_DIR: /home/ec2-user/.local/bin
-  #     SCCACHE_CACHE_SIZE: 20G
-  #     SCCACHE_DIR: /home/ec2-user/.cache/sccache
-  #     SCCACHE_IDLE_TIMEOUT: 0
-  #     WORK_DIR: /home/ec2-user/actions-runner/_work/plrust/plrust
+    # Note about environment variables: Even though a majority of these environment variables are baked into the runner image,
+    # Github Actions seemingly runs self-hosted tasks in a different manner such that even baken-in environment variables are
+    # removed. Howevever, they can be declared here and persist through all tasks. Assume that the home directory for the
+    # runner is /home/ec2-user
+    env:
+      AWS_CACHE_BUCKET: tcdi-ci-plrust-build-cache.private
+      CACHE_KEY_VERSION: v0
+      CI: true
+      PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/ec2-user/actions-runner/_work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
+      RUSTUP_HOME: /home/ec2-user/.rustup
+      RUSTC_WRAPPER: sccache
+      RUSTFLAGS: -Copt-level=0 -Dwarnings
+      SCCACHE_BIN_DIR: /home/ec2-user/.local/bin
+      SCCACHE_CACHE_SIZE: 20G
+      SCCACHE_DIR: /home/ec2-user/.cache/sccache
+      SCCACHE_IDLE_TIMEOUT: 0
+      WORK_DIR: /home/ec2-user/actions-runner/_work/plrust/plrust
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Generate cache filename checksum
-  #     run: |
-  #       cd $WORK_DIR
-  #       shopt -s globstar
-  #       checksum=$(cat **/Cargo.lock **/rust-toolchain.toml .github/workflows/ci.yml .cargo/config | sha256sum | awk '{print $1}')
-  #       echo "CACHE_KEY_CHECKSUM=$checksum" >> $GITHUB_ENV
+    - name: Generate cache filename checksum
+      run: |
+        cd $WORK_DIR
+        shopt -s globstar
+        checksum=$(cat **/Cargo.lock **/rust-toolchain.toml .github/workflows/ci.yml .cargo/config | sha256sum | awk '{print $1}')
+        echo "CACHE_KEY_CHECKSUM=$checksum" >> $GITHUB_ENV
 
-  #   - name: Set up (Linux) prerequisites and environment
-  #     run: |
-  #       echo ""
-  #       echo "----- Print kernel info -----"
-  #       uname -a
-  #       echo ""
+    - name: Set up (Linux) prerequisites and environment
+      run: |
+        echo ""
+        echo "----- Print kernel info -----"
+        uname -a
+        echo ""
 
-  #       echo "----- Set up dynamic variables -----"
-  #       export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
-  #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-  #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-  #       echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
-  #       echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
-  #       echo ""
+        echo "----- Set up dynamic variables -----"
+        export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
+        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+        echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
+        echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+        echo ""
 
-  #       echo "----- Install system dependencies -----"
-  #       # Add any extra dependencies here if necessary
+        echo "----- Install system dependencies -----"
+        # Add any extra dependencies here if necessary
 
-  #       echo "----- Install PostgreSQL $PG_VER -----"
-  #       sudo yum install -y "postgresql$PG_VER" "postgresql$PG_VER-server" "postgresql$PG_VER-devel"
-  #       export PATH="/usr/pgsql-$PG_VER/bin/:$PATH"
-  #       echo "/usr/pgsql-$PG_VER/bin/" >> $GITHUB_PATH
+        echo "----- Install PostgreSQL $PG_VER -----"
+        sudo yum install -y "postgresql$PG_VER" "postgresql$PG_VER-server" "postgresql$PG_VER-devel"
+        export PATH="/usr/pgsql-$PG_VER/bin/:$PATH"
+        echo "/usr/pgsql-$PG_VER/bin/" >> $GITHUB_PATH
 
-  #       echo "----- Set postgres permissions -----"
-  #       sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-  #       echo ""
+        echo "----- Set postgres permissions -----"
+        sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+        echo ""
 
-  #       echo "----- Create artifacts directory -----"
-  #       mkdir -p $HOME/artifacts
-  #       echo ""
+        echo "----- Create artifacts directory -----"
+        mkdir -p $HOME/artifacts
+        echo ""
 
-  #       cat $GITHUB_ENV
-  #       echo ""
-  #       env
+        cat $GITHUB_ENV
+        echo ""
+        env
 
-  #   - name: Load Cargo cache if available
-  #     run: |
-  #       # See <plrust-root>/.github/scripts/load_cache.sh for more details
-  #       . $WORK_DIR/.github/scripts/load_cache.sh
-  #       cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-  #       loadcache $cargo_cache_key
+    - name: Load Cargo cache if available
+      run: |
+        # See <plrust-root>/.github/scripts/load_cache.sh for more details
+        . $WORK_DIR/.github/scripts/load_cache.sh
+        cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+        loadcache $cargo_cache_key
 
-  #   - name: Create protected files
-  #     run: |
-  #       sudo mkdir -p /var/ci-stuff/secret_rust_files
-  #       sudo echo "const FOO:i32 = 7;" /var/ci-stuff/secret_rust_files/const_foo.rs
-  #       sudo echo "const BAR:i32 = 8;" /var/ci-stuff/const_bar.rs
-  #       sudo chmod -R 600 /var/ci-stuff/secret_rust_files
-  #     if: matrix.target == 'postgrestd'
+    - name: Create protected files
+      run: |
+        sudo mkdir -p /var/ci-stuff/secret_rust_files
+        sudo echo "const FOO:i32 = 7;" /var/ci-stuff/secret_rust_files/const_foo.rs
+        sudo echo "const BAR:i32 = 8;" /var/ci-stuff/const_bar.rs
+        sudo chmod -R 600 /var/ci-stuff/secret_rust_files
+      if: matrix.target == 'postgrestd'
 
-  #   - name: Load sccache cache if available
-  #     run: |
-  #       # See <plrust-root>/.github/scripts/load_cache.sh for more details
-  #       . $WORK_DIR/.github/scripts/load_cache.sh
-  #       sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-  #       loadcache $sccache_key
+    - name: Load sccache cache if available
+      run: |
+        # See <plrust-root>/.github/scripts/load_cache.sh for more details
+        . $WORK_DIR/.github/scripts/load_cache.sh
+        sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+        loadcache $sccache_key
 
-  #   - name: Start sccache server
-  #     run: sccache --start-server && sccache --show-stats
+    - name: Start sccache server
+      run: sccache --start-server && sccache --show-stats
 
-  #   # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
-  #   - name: Install cargo-pgrx defined in plrust/Cargo.toml
-  #     run: |
-  #       . $WORK_DIR/.github/scripts/install_cargo_pgrx.sh
-  #       install_cargo_pgrx
+    # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
+    - name: Install cargo-pgrx defined in plrust/Cargo.toml
+      run: |
+        . $WORK_DIR/.github/scripts/install_cargo_pgrx.sh
+        install_cargo_pgrx
 
-  #   - name: Print sccache stats
-  #     run: sccache --show-stats
+    - name: Print sccache stats
+      run: sccache --show-stats
 
-  #   - name: Install llvm-tools-preview
-  #     run: rustup component add llvm-tools-preview rustc-dev
+    - name: Install llvm-tools-preview
+      run: rustup component add llvm-tools-preview rustc-dev
 
-  #   - name: Test plrustc
-  #     run: cd plrustc && cargo test -p plrustc
+    - name: Test plrustc
+      run: cd plrustc && cargo test -p plrustc
 
-  #   - name: Print sccache stats
-  #     run: sccache --show-stats
+    - name: Print sccache stats
+      run: sccache --show-stats
 
-  #   - name: install plrustc
-  #     run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
+    - name: install plrustc
+      run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 
-  #   - name: Print sccache stats
-  #     run: sccache --show-stats
+    - name: Print sccache stats
+      run: sccache --show-stats
 
-  #   - name: Run cargo pgrx init
-  #     run: cargo pgrx init --pg$PG_VER $(which pg_config)
+    - name: Run cargo pgrx init
+      run: cargo pgrx init --pg$PG_VER $(which pg_config)
 
-  #   - name: Test PL/rust as "untrusted"
-  #     if: matrix.target == 'host'
-  #     run: cargo test --all --features "pg$PG_VER" --no-default-features
+    - name: Test PL/rust as "untrusted"
+      if: matrix.target == 'host'
+      run: cargo test --all --features "pg$PG_VER" --no-default-features
 
-  #   - name: Test PL/rust as "trusted" (inc. postgrestd)
-  #     if: matrix.target == 'postgrestd'
-  #     run: cd plrust && STD_TARGETS="aarch64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
+    - name: Test PL/rust as "trusted" (inc. postgrestd)
+      if: matrix.target == 'postgrestd'
+      run: cd plrust && STD_TARGETS="aarch64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
 
-  #   - name: Print sccache stats (after build)
-  #     run: sccache --show-stats
+    - name: Print sccache stats (after build)
+      run: sccache --show-stats
 
-  #   - name: Stop sccache server
-  #     run: sccache --stop-server || true
+    - name: Stop sccache server
+      run: sccache --stop-server || true
 
-  #   - name: Store Cargo cache if applicable
-  #     run: |
-  #       . $WORK_DIR/.github/scripts/save_cache.sh
-  #       # See <plrust-root>/.github/scripts/save_cache.sh for more details
-  #       cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-  #       cargo_dirs=( \
-  #           $HOME/.cargo/ \
-  #       )
-  #       savecache $cargo_cache_key "${cargo_dirs[@]}"
+    - name: Store Cargo cache if applicable
+      run: |
+        . $WORK_DIR/.github/scripts/save_cache.sh
+        # See <plrust-root>/.github/scripts/save_cache.sh for more details
+        cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+        cargo_dirs=( \
+            $HOME/.cargo/ \
+        )
+        savecache $cargo_cache_key "${cargo_dirs[@]}"
 
-  #   - name: Store sccache if applicable
-  #     run: |
-  #       # See <plrust-root>/.github/scripts/save_cache.sh for more details
-  #       . $WORK_DIR/.github/scripts/save_cache.sh
-  #       sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-  #       sccache_dirs=($SCCACHE_DIR)
-  #       savecache $sccache_key "${sccache_dirs[@]}"
+    - name: Store sccache if applicable
+      run: |
+        # See <plrust-root>/.github/scripts/save_cache.sh for more details
+        . $WORK_DIR/.github/scripts/save_cache.sh
+        sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+        sccache_dirs=($SCCACHE_DIR)
+        savecache $sccache_key "${sccache_dirs[@]}"
 
   plrust_x86_64:
     name: x86_64 tests
@@ -271,10 +271,10 @@ jobs:
         echo ""
 
         sudo apt-get install -y \
-          postgresql-$PG_VER \
-          postgresql-server-dev-$PG_VER
+          postgresql-"$PG_VER" \
+          postgresql-server-dev-"$PG_VER"
 
-    - name: Install develoment version of PostgreSQL
+    - name: Install development version of PostgreSQL
       if: matrix.version == 'pg16'
       run: |
         echo "----- Set up PostgreSQL Apt repository -----"
@@ -287,11 +287,11 @@ jobs:
         echo ""
 
         sudo apt-get install -y \
-          postgresql-$PG_VER \
-          postgresql-server-dev-$PG_VER
+          postgresql-"$PG_VER" \
+          postgresql-server-dev-"$PG_VER"
 
     - name: Set up Postgres permissions
-      run: sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
+      run: sudo chmod a+rwx "$(/usr/lib/postgresql/"$PG_VER"/bin/pg_config --pkglibdir)" "$(/usr/lib/postgresql/"$PG_VER"/bin/pg_config --sharedir)"/extension /var/run/postgresql/
 
     - name: Cache cargo registry
       uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        version: ["pg13", "pg14", "pg15"]
+        # version: ["pg13", "pg14", "pg15"]
+        version: ["pg16"]
         target: ["host", "postgrestd"]
       fail-fast: false
 
@@ -180,163 +181,163 @@ jobs:
         sccache_dirs=($SCCACHE_DIR)
         savecache $sccache_key "${sccache_dirs[@]}"
 
-  plrust_x86_64:
-    name: x86_64 tests
-    runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, 'nogha')"
+  # plrust_x86_64:
+  #   name: x86_64 tests
+  #   runs-on: ${{ matrix.os }}
+  #   if: "!contains(github.event.head_commit.message, 'nogha')"
 
-    env:
-      PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/runner/work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
-      RUSTC_WRAPPER: sccache
-      RUSTFLAGS: -Copt-level=0 -Dwarnings
-      SCCACHE_BIN_DIR: /home/runner/.local/bin
-      SCCACHE_CACHE_SIZE: 20G
-      SCCACHE_DIR: /home/runner/.cache/sccache
-      SCCACHE_IDLE_TIMEOUT: 0
+  #   env:
+  #     PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/runner/work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
+  #     RUSTC_WRAPPER: sccache
+  #     RUSTFLAGS: -Copt-level=0 -Dwarnings
+  #     SCCACHE_BIN_DIR: /home/runner/.local/bin
+  #     SCCACHE_CACHE_SIZE: 20G
+  #     SCCACHE_DIR: /home/runner/.cache/sccache
+  #     SCCACHE_IDLE_TIMEOUT: 0
 
-    strategy:
-      matrix:
-        version: ["pg13", "pg14", "pg15"]
-        os: ["ubuntu-latest"]
-        # it would be nice to other contributors to return "macos-11" to the above array
-        target: ["host", "postgrestd"]
-      fail-fast: false
+  #   strategy:
+  #     matrix:
+  #       version: ["pg13", "pg14", "pg15"]
+  #       os: ["ubuntu-latest"]
+  #       # it would be nice to other contributors to return "macos-11" to the above array
+  #       target: ["host", "postgrestd"]
+  #     fail-fast: false
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Set up (Linux) prerequisites and environment
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo ""
+  #   - name: Set up (Linux) prerequisites and environment
+  #     if: matrix.os == 'ubuntu-latest'
+  #     run: |
+  #       echo ""
 
-        echo "----- Set up dynamic variables -----"
-        export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
-        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
+  #       echo "----- Set up dynamic variables -----"
+  #       export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
+  #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+  #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+  #       cat $GITHUB_ENV
+  #       echo ""
 
 
-        echo "----- Install sccache -----"
-        mkdir -p $SCCACHE_BIN_DIR
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.5.0/sccache-v0.5.0-x86_64-unknown-linux-musl.tar.gz | tar xz
-        mv -f sccache-v0.5.0-x86_64-unknown-linux-musl/sccache $SCCACHE_BIN_DIR/sccache
-        chmod +x $SCCACHE_BIN_DIR/sccache
-        echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
-        mkdir -p $SCCACHE_DIR
-        echo ""
+  #       echo "----- Install sccache -----"
+  #       mkdir -p $SCCACHE_BIN_DIR
+  #       curl -L https://github.com/mozilla/sccache/releases/download/v0.5.0/sccache-v0.5.0-x86_64-unknown-linux-musl.tar.gz | tar xz
+  #       mv -f sccache-v0.5.0-x86_64-unknown-linux-musl/sccache $SCCACHE_BIN_DIR/sccache
+  #       chmod +x $SCCACHE_BIN_DIR/sccache
+  #       echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
+  #       mkdir -p $SCCACHE_DIR
+  #       echo ""
 
-        echo "----- Remove old postgres -----"
-        sudo apt remove -y postgres*
-        echo ""
+  #       echo "----- Remove old postgres -----"
+  #       sudo apt remove -y postgres*
+  #       echo ""
 
-        echo "----- Set up PostgreSQL Apt repository -----"
-        sudo apt-get install -y wget gnupg
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null && \
-        sudo apt-get update -y -qq --fix-missing
-        echo ""
+  #       echo "----- Set up PostgreSQL Apt repository -----"
+  #       sudo apt-get install -y wget gnupg
+  #       sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+  #       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null && \
+  #       sudo apt-get update -y -qq --fix-missing
+  #       echo ""
 
-        echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
-        sudo apt-get install -y \
-          build-essential \
-          clang \
-          clang-11 \
-          gcc \
-          libssl-dev \
-          libz-dev \
-          llvm-11 \
-          make \
-          pkg-config \
-          postgresql-$PG_VER \
-          postgresql-server-dev-$PG_VER \
-          strace \
-          zlib1g-dev
-        echo ""
+  #       echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
+  #       sudo apt-get install -y \
+  #         build-essential \
+  #         clang \
+  #         clang-11 \
+  #         gcc \
+  #         libssl-dev \
+  #         libz-dev \
+  #         llvm-11 \
+  #         make \
+  #         pkg-config \
+  #         postgresql-$PG_VER \
+  #         postgresql-server-dev-$PG_VER \
+  #         strace \
+  #         zlib1g-dev
+  #       echo ""
 
-        echo "----- Set up Postgres permissions -----"
-        sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
-        echo ""
+  #       echo "----- Set up Postgres permissions -----"
+  #       sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
+  #       echo ""
 
-        echo "----- Print env -----"
-        env
-        echo ""
+  #       echo "----- Print env -----"
+  #       env
+  #       echo ""
 
-        echo "----- Get cargo version -----"
-        cargo --version
-        echo ""
+  #       echo "----- Get cargo version -----"
+  #       cargo --version
+  #       echo ""
 
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      continue-on-error: false
-      with:
-        path: |
-          /home/runner/.cargo
-        key: v0-plrust-x86_64-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
+  #   - name: Cache cargo registry
+  #     uses: actions/cache@v3
+  #     continue-on-error: false
+  #     with:
+  #       path: |
+  #         /home/runner/.cargo
+  #       key: v0-plrust-x86_64-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
 
-    - name: Cache sccache directory
-      uses: actions/cache@v3
-      continue-on-error: false
-      with:
-        path: |
-          /home/runner/.cache/sccache
-        key: v0-plrust-x86_64-sccache-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
+  #   - name: Cache sccache directory
+  #     uses: actions/cache@v3
+  #     continue-on-error: false
+  #     with:
+  #       path: |
+  #         /home/runner/.cache/sccache
+  #       key: v0-plrust-x86_64-sccache-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
 
-    - name: Start sccache server
-      run: sccache --start-server && sccache --show-stats
+  #   - name: Start sccache server
+  #     run: sccache --start-server && sccache --show-stats
 
-    - name: sccache dir
-      run: ls -lath /home/runner/.cache/sccache
+  #   - name: sccache dir
+  #     run: ls -lath /home/runner/.cache/sccache
 
-    # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
-    - name: Install cargo-pgrx defined in plrust/Cargo.toml
-      run: |
-        . $GITHUB_WORKSPACE/.github/scripts/install_cargo_pgrx.sh
-        install_cargo_pgrx
+  #   # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
+  #   - name: Install cargo-pgrx defined in plrust/Cargo.toml
+  #     run: |
+  #       . $GITHUB_WORKSPACE/.github/scripts/install_cargo_pgrx.sh
+  #       install_cargo_pgrx
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+  #   - name: Print sccache stats
+  #     run: sccache --show-stats
 
-    - name: Install llvm-tools-preview
-      run: rustup component add llvm-tools-preview rustc-dev
+  #   - name: Install llvm-tools-preview
+  #     run: rustup component add llvm-tools-preview rustc-dev
 
-    - name: Create protected files
-      run: |
-        sudo mkdir -p /var/ci-stuff/secret_rust_files
-        sudo echo "const FOO:i32 = 7;" /var/ci-stuff/secret_rust_files/const_foo.rs
-        sudo echo "const BAR:i32 = 8;" /var/ci-stuff/const_bar.rs
-        sudo chmod -R 600 /var/ci-stuff/secret_rust_files
-      if: matrix.target == 'postgrestd'
+  #   - name: Create protected files
+  #     run: |
+  #       sudo mkdir -p /var/ci-stuff/secret_rust_files
+  #       sudo echo "const FOO:i32 = 7;" /var/ci-stuff/secret_rust_files/const_foo.rs
+  #       sudo echo "const BAR:i32 = 8;" /var/ci-stuff/const_bar.rs
+  #       sudo chmod -R 600 /var/ci-stuff/secret_rust_files
+  #     if: matrix.target == 'postgrestd'
 
-    - name: Test plrustc
-      run: cd plrustc && cargo test -p plrustc
+  #   - name: Test plrustc
+  #     run: cd plrustc && cargo test -p plrustc
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+  #   - name: Print sccache stats
+  #     run: sccache --show-stats
 
-    - name: Install plrustc
-      run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
+  #   - name: Install plrustc
+  #     run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+  #   - name: Print sccache stats
+  #     run: sccache --show-stats
 
-    - name: Run 'cargo pgrx init' against system-level ${{ matrix.version }}
-      run: cargo pgrx init --pg$PG_VER $(which pg_config)
+  #   - name: Run 'cargo pgrx init' against system-level ${{ matrix.version }}
+  #     run: cargo pgrx init --pg$PG_VER $(which pg_config)
 
-    - name: Test PL/rust as "untrusted"
-      if: matrix.target == 'host'
-      run: cargo test --all --features "pg$PG_VER" --no-default-features
+  #   - name: Test PL/rust as "untrusted"
+  #     if: matrix.target == 'host'
+  #     run: cargo test --all --features "pg$PG_VER" --no-default-features
 
-    - name: Test PL/rust as "trusted" (inc. postgrestd)
-      if: matrix.target == 'postgrestd'
-      run: cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
+  #   - name: Test PL/rust as "trusted" (inc. postgrestd)
+  #     if: matrix.target == 'postgrestd'
+  #     run: cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+  #   - name: Print sccache stats
+  #     run: sccache --show-stats
 
-    - name: sccache dir
-      run: ls -lath /home/runner/.cache/sccache
+  #   - name: sccache dir
+  #     run: ls -lath /home/runner/.cache/sccache
 
-    - name: Stop sccache server
-      run: sccache --stop-server || true
+  #   - name: Stop sccache server
+  #     run: sccache --stop-server || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,287 +20,88 @@ jobs:
   # The image created for running these tasks already have a majority of the dependencies installed, such as system
   # libraries, sccache, github runners, rust, etc. This is to cut back on the amount of time it takes to launch a runner.
   # If something is missing, it can be added here or baked into a new image outside of Github Actions.
-  plrust_arm64_amzn2:
-    name: aarch64 tests (amzn2)
-    runs-on: [self-hosted, linux, ARM64, launch_template_id__lt-0013395587950cb5d]
-    defaults:
-      run:
-        shell: bash
-
-    strategy:
-      matrix:
-        # version: ["pg13", "pg14", "pg15"]
-        version: ["pg16"]
-        target: ["host", "postgrestd"]
-      fail-fast: false
-
-    # Note about environment variables: Even though a majority of these environment variables are baked into the runner image,
-    # Github Actions seemingly runs self-hosted tasks in a different manner such that even baken-in environment variables are
-    # removed. Howevever, they can be declared here and persist through all tasks. Assume that the home directory for the
-    # runner is /home/ec2-user
-    env:
-      AWS_CACHE_BUCKET: tcdi-ci-plrust-build-cache.private
-      CACHE_KEY_VERSION: v0
-      CI: true
-      PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/ec2-user/actions-runner/_work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
-      RUSTUP_HOME: /home/ec2-user/.rustup
-      RUSTC_WRAPPER: sccache
-      RUSTFLAGS: -Copt-level=0 -Dwarnings
-      SCCACHE_BIN_DIR: /home/ec2-user/.local/bin
-      SCCACHE_CACHE_SIZE: 20G
-      SCCACHE_DIR: /home/ec2-user/.cache/sccache
-      SCCACHE_IDLE_TIMEOUT: 0
-      WORK_DIR: /home/ec2-user/actions-runner/_work/plrust/plrust
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Generate cache filename checksum
-      run: |
-        cd $WORK_DIR
-        shopt -s globstar
-        checksum=$(cat **/Cargo.lock **/rust-toolchain.toml .github/workflows/ci.yml .cargo/config | sha256sum | awk '{print $1}')
-        echo "CACHE_KEY_CHECKSUM=$checksum" >> $GITHUB_ENV
-
-    - name: Set up (Linux) prerequisites and environment
-      run: |
-        echo ""
-        echo "----- Print kernel info -----"
-        uname -a
-        echo ""
-
-        echo "----- Set up dynamic variables -----"
-        export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
-        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
-        echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
-        echo ""
-
-        echo "----- Install system dependencies -----"
-        # Add any extra dependencies here if necessary
-
-        echo "----- Install PostgreSQL $PG_VER -----"
-        sudo yum install -y "postgresql$PG_VER" "postgresql$PG_VER-server" "postgresql$PG_VER-devel"
-        export PATH="/usr/pgsql-$PG_VER/bin/:$PATH"
-        echo "/usr/pgsql-$PG_VER/bin/" >> $GITHUB_PATH
-
-        echo "----- Set postgres permissions -----"
-        sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-        echo ""
-
-        echo "----- Create artifacts directory -----"
-        mkdir -p $HOME/artifacts
-        echo ""
-
-        cat $GITHUB_ENV
-        echo ""
-        env
-
-    - name: Load Cargo cache if available
-      run: |
-        # See <plrust-root>/.github/scripts/load_cache.sh for more details
-        . $WORK_DIR/.github/scripts/load_cache.sh
-        cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-        loadcache $cargo_cache_key
-
-    - name: Create protected files
-      run: |
-        sudo mkdir -p /var/ci-stuff/secret_rust_files
-        sudo echo "const FOO:i32 = 7;" /var/ci-stuff/secret_rust_files/const_foo.rs
-        sudo echo "const BAR:i32 = 8;" /var/ci-stuff/const_bar.rs
-        sudo chmod -R 600 /var/ci-stuff/secret_rust_files
-      if: matrix.target == 'postgrestd'
-
-    - name: Load sccache cache if available
-      run: |
-        # See <plrust-root>/.github/scripts/load_cache.sh for more details
-        . $WORK_DIR/.github/scripts/load_cache.sh
-        sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-        loadcache $sccache_key
-
-    - name: Start sccache server
-      run: sccache --start-server && sccache --show-stats
-
-    # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
-    - name: Install cargo-pgrx defined in plrust/Cargo.toml
-      run: |
-        . $WORK_DIR/.github/scripts/install_cargo_pgrx.sh
-        install_cargo_pgrx
-
-    - name: Print sccache stats
-      run: sccache --show-stats
-
-    - name: Install llvm-tools-preview
-      run: rustup component add llvm-tools-preview rustc-dev
-
-    - name: Test plrustc
-      run: cd plrustc && cargo test -p plrustc
-
-    - name: Print sccache stats
-      run: sccache --show-stats
-
-    - name: install plrustc
-      run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
-
-    - name: Print sccache stats
-      run: sccache --show-stats
-
-    - name: Run cargo pgrx init
-      run: cargo pgrx init --pg$PG_VER $(which pg_config)
-
-    - name: Test PL/rust as "untrusted"
-      if: matrix.target == 'host'
-      run: cargo test --all --features "pg$PG_VER" --no-default-features
-
-    - name: Test PL/rust as "trusted" (inc. postgrestd)
-      if: matrix.target == 'postgrestd'
-      run: cd plrust && STD_TARGETS="aarch64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
-
-    - name: Print sccache stats (after build)
-      run: sccache --show-stats
-
-    - name: Stop sccache server
-      run: sccache --stop-server || true
-
-    - name: Store Cargo cache if applicable
-      run: |
-        . $WORK_DIR/.github/scripts/save_cache.sh
-        # See <plrust-root>/.github/scripts/save_cache.sh for more details
-        cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-        cargo_dirs=( \
-            $HOME/.cargo/ \
-        )
-        savecache $cargo_cache_key "${cargo_dirs[@]}"
-
-    - name: Store sccache if applicable
-      run: |
-        # See <plrust-root>/.github/scripts/save_cache.sh for more details
-        . $WORK_DIR/.github/scripts/save_cache.sh
-        sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
-        sccache_dirs=($SCCACHE_DIR)
-        savecache $sccache_key "${sccache_dirs[@]}"
-
-  # plrust_x86_64:
-  #   name: x86_64 tests
-  #   runs-on: ${{ matrix.os }}
-  #   if: "!contains(github.event.head_commit.message, 'nogha')"
-
-  #   env:
-  #     PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/runner/work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
-  #     RUSTC_WRAPPER: sccache
-  #     RUSTFLAGS: -Copt-level=0 -Dwarnings
-  #     SCCACHE_BIN_DIR: /home/runner/.local/bin
-  #     SCCACHE_CACHE_SIZE: 20G
-  #     SCCACHE_DIR: /home/runner/.cache/sccache
-  #     SCCACHE_IDLE_TIMEOUT: 0
+  # plrust_arm64_amzn2:
+  #   name: aarch64 tests (amzn2)
+  #   runs-on: [self-hosted, linux, ARM64, launch_template_id__lt-0013395587950cb5d]
+  #   defaults:
+  #     run:
+  #       shell: bash
 
   #   strategy:
   #     matrix:
-  #       version: ["pg13", "pg14", "pg15"]
-  #       os: ["ubuntu-latest"]
-  #       # it would be nice to other contributors to return "macos-11" to the above array
+  #       version: ["pg13", "pg14", "pg15", "pg16"]
   #       target: ["host", "postgrestd"]
   #     fail-fast: false
+
+  #   # Note about environment variables: Even though a majority of these environment variables are baked into the runner image,
+  #   # Github Actions seemingly runs self-hosted tasks in a different manner such that even baken-in environment variables are
+  #   # removed. Howevever, they can be declared here and persist through all tasks. Assume that the home directory for the
+  #   # runner is /home/ec2-user
+  #   env:
+  #     AWS_CACHE_BUCKET: tcdi-ci-plrust-build-cache.private
+  #     CACHE_KEY_VERSION: v0
+  #     CI: true
+  #     PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/ec2-user/actions-runner/_work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
+  #     RUSTUP_HOME: /home/ec2-user/.rustup
+  #     RUSTC_WRAPPER: sccache
+  #     RUSTFLAGS: -Copt-level=0 -Dwarnings
+  #     SCCACHE_BIN_DIR: /home/ec2-user/.local/bin
+  #     SCCACHE_CACHE_SIZE: 20G
+  #     SCCACHE_DIR: /home/ec2-user/.cache/sccache
+  #     SCCACHE_IDLE_TIMEOUT: 0
+  #     WORK_DIR: /home/ec2-user/actions-runner/_work/plrust/plrust
 
   #   steps:
   #   - uses: actions/checkout@v3
 
-  #   - name: Set up (Linux) prerequisites and environment
-  #     if: matrix.os == 'ubuntu-latest'
+  #   - name: Generate cache filename checksum
   #     run: |
+  #       cd $WORK_DIR
+  #       shopt -s globstar
+  #       checksum=$(cat **/Cargo.lock **/rust-toolchain.toml .github/workflows/ci.yml .cargo/config | sha256sum | awk '{print $1}')
+  #       echo "CACHE_KEY_CHECKSUM=$checksum" >> $GITHUB_ENV
+
+  #   - name: Set up (Linux) prerequisites and environment
+  #     run: |
+  #       echo ""
+  #       echo "----- Print kernel info -----"
+  #       uname -a
   #       echo ""
 
   #       echo "----- Set up dynamic variables -----"
   #       export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
   #       echo "PG_VER=$PG_VER" >> $GITHUB_ENV
   #       echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+  #       echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
+  #       echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+  #       echo ""
+
+  #       echo "----- Install system dependencies -----"
+  #       # Add any extra dependencies here if necessary
+
+  #       echo "----- Install PostgreSQL $PG_VER -----"
+  #       sudo yum install -y "postgresql$PG_VER" "postgresql$PG_VER-server" "postgresql$PG_VER-devel"
+  #       export PATH="/usr/pgsql-$PG_VER/bin/:$PATH"
+  #       echo "/usr/pgsql-$PG_VER/bin/" >> $GITHUB_PATH
+
+  #       echo "----- Set postgres permissions -----"
+  #       sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+  #       echo ""
+
+  #       echo "----- Create artifacts directory -----"
+  #       mkdir -p $HOME/artifacts
+  #       echo ""
+
   #       cat $GITHUB_ENV
   #       echo ""
-
-
-  #       echo "----- Install sccache -----"
-  #       mkdir -p $SCCACHE_BIN_DIR
-  #       curl -L https://github.com/mozilla/sccache/releases/download/v0.5.0/sccache-v0.5.0-x86_64-unknown-linux-musl.tar.gz | tar xz
-  #       mv -f sccache-v0.5.0-x86_64-unknown-linux-musl/sccache $SCCACHE_BIN_DIR/sccache
-  #       chmod +x $SCCACHE_BIN_DIR/sccache
-  #       echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
-  #       mkdir -p $SCCACHE_DIR
-  #       echo ""
-
-  #       echo "----- Remove old postgres -----"
-  #       sudo apt remove -y postgres*
-  #       echo ""
-
-  #       echo "----- Set up PostgreSQL Apt repository -----"
-  #       sudo apt-get install -y wget gnupg
-  #       sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-  #       wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null && \
-  #       sudo apt-get update -y -qq --fix-missing
-  #       echo ""
-
-  #       echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
-  #       sudo apt-get install -y \
-  #         build-essential \
-  #         clang \
-  #         clang-11 \
-  #         gcc \
-  #         libssl-dev \
-  #         libz-dev \
-  #         llvm-11 \
-  #         make \
-  #         pkg-config \
-  #         postgresql-$PG_VER \
-  #         postgresql-server-dev-$PG_VER \
-  #         strace \
-  #         zlib1g-dev
-  #       echo ""
-
-  #       echo "----- Set up Postgres permissions -----"
-  #       sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
-  #       echo ""
-
-  #       echo "----- Print env -----"
   #       env
-  #       echo ""
 
-  #       echo "----- Get cargo version -----"
-  #       cargo --version
-  #       echo ""
-
-  #   - name: Cache cargo registry
-  #     uses: actions/cache@v3
-  #     continue-on-error: false
-  #     with:
-  #       path: |
-  #         /home/runner/.cargo
-  #       key: v0-plrust-x86_64-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
-
-  #   - name: Cache sccache directory
-  #     uses: actions/cache@v3
-  #     continue-on-error: false
-  #     with:
-  #       path: |
-  #         /home/runner/.cache/sccache
-  #       key: v0-plrust-x86_64-sccache-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
-
-  #   - name: Start sccache server
-  #     run: sccache --start-server && sccache --show-stats
-
-  #   - name: sccache dir
-  #     run: ls -lath /home/runner/.cache/sccache
-
-  #   # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
-  #   - name: Install cargo-pgrx defined in plrust/Cargo.toml
+  #   - name: Load Cargo cache if available
   #     run: |
-  #       . $GITHUB_WORKSPACE/.github/scripts/install_cargo_pgrx.sh
-  #       install_cargo_pgrx
-
-  #   - name: Print sccache stats
-  #     run: sccache --show-stats
-
-  #   - name: Install llvm-tools-preview
-  #     run: rustup component add llvm-tools-preview rustc-dev
+  #       # See <plrust-root>/.github/scripts/load_cache.sh for more details
+  #       . $WORK_DIR/.github/scripts/load_cache.sh
+  #       cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+  #       loadcache $cargo_cache_key
 
   #   - name: Create protected files
   #     run: |
@@ -310,19 +111,41 @@ jobs:
   #       sudo chmod -R 600 /var/ci-stuff/secret_rust_files
   #     if: matrix.target == 'postgrestd'
 
+  #   - name: Load sccache cache if available
+  #     run: |
+  #       # See <plrust-root>/.github/scripts/load_cache.sh for more details
+  #       . $WORK_DIR/.github/scripts/load_cache.sh
+  #       sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+  #       loadcache $sccache_key
+
+  #   - name: Start sccache server
+  #     run: sccache --start-server && sccache --show-stats
+
+  #   # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
+  #   - name: Install cargo-pgrx defined in plrust/Cargo.toml
+  #     run: |
+  #       . $WORK_DIR/.github/scripts/install_cargo_pgrx.sh
+  #       install_cargo_pgrx
+
+  #   - name: Print sccache stats
+  #     run: sccache --show-stats
+
+  #   - name: Install llvm-tools-preview
+  #     run: rustup component add llvm-tools-preview rustc-dev
+
   #   - name: Test plrustc
   #     run: cd plrustc && cargo test -p plrustc
 
   #   - name: Print sccache stats
   #     run: sccache --show-stats
 
-  #   - name: Install plrustc
+  #   - name: install plrustc
   #     run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
 
   #   - name: Print sccache stats
   #     run: sccache --show-stats
 
-  #   - name: Run 'cargo pgrx init' against system-level ${{ matrix.version }}
+  #   - name: Run cargo pgrx init
   #     run: cargo pgrx init --pg$PG_VER $(which pg_config)
 
   #   - name: Test PL/rust as "untrusted"
@@ -331,13 +154,215 @@ jobs:
 
   #   - name: Test PL/rust as "trusted" (inc. postgrestd)
   #     if: matrix.target == 'postgrestd'
-  #     run: cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
+  #     run: cd plrust && STD_TARGETS="aarch64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
 
-  #   - name: Print sccache stats
+  #   - name: Print sccache stats (after build)
   #     run: sccache --show-stats
-
-  #   - name: sccache dir
-  #     run: ls -lath /home/runner/.cache/sccache
 
   #   - name: Stop sccache server
   #     run: sccache --stop-server || true
+
+  #   - name: Store Cargo cache if applicable
+  #     run: |
+  #       . $WORK_DIR/.github/scripts/save_cache.sh
+  #       # See <plrust-root>/.github/scripts/save_cache.sh for more details
+  #       cargo_cache_key="plrust-arm64-amzn2-cargo-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+  #       cargo_dirs=( \
+  #           $HOME/.cargo/ \
+  #       )
+  #       savecache $cargo_cache_key "${cargo_dirs[@]}"
+
+  #   - name: Store sccache if applicable
+  #     run: |
+  #       # See <plrust-root>/.github/scripts/save_cache.sh for more details
+  #       . $WORK_DIR/.github/scripts/save_cache.sh
+  #       sccache_key="plrust-arm64-amzn2-sccache-cache-$CACHE_KEY_VERSION-$CACHE_KEY_CHECKSUM.tar.lz4"
+  #       sccache_dirs=($SCCACHE_DIR)
+  #       savecache $sccache_key "${sccache_dirs[@]}"
+
+  plrust_x86_64:
+    name: x86_64 tests
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'nogha')"
+
+    env:
+      PLRUST_TRUSTED_PGRX_OVERRIDE: "pgrx = { path = '/home/runner/work/plrust/plrust/plrust-trusted-pgrx', package='plrust-trusted-pgrx' }"
+      RUSTC_WRAPPER: sccache
+      RUSTFLAGS: -Copt-level=0 -Dwarnings
+      SCCACHE_BIN_DIR: /home/runner/.local/bin
+      SCCACHE_CACHE_SIZE: 20G
+      SCCACHE_DIR: /home/runner/.cache/sccache
+      SCCACHE_IDLE_TIMEOUT: 0
+
+    strategy:
+      matrix:
+        version: ["pg13", "pg14", "pg15", "pg16"]
+        os: ["ubuntu-latest"]
+        # it would be nice to other contributors to return "macos-11" to the above array
+        target: ["host", "postgrestd"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up (Linux) prerequisites and environment
+      run: |
+        echo ""
+
+        echo "----- Set up dynamic variables -----"
+        export PG_VER=$(echo ${{ matrix.version }} | cut -c 3-)
+        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
+
+
+        echo "----- Install sccache -----"
+        mkdir -p $SCCACHE_BIN_DIR
+        curl -L https://github.com/mozilla/sccache/releases/download/v0.5.0/sccache-v0.5.0-x86_64-unknown-linux-musl.tar.gz | tar xz
+        mv -f sccache-v0.5.0-x86_64-unknown-linux-musl/sccache $SCCACHE_BIN_DIR/sccache
+        chmod +x $SCCACHE_BIN_DIR/sccache
+        echo "$SCCACHE_BIN_DIR" >> $GITHUB_PATH
+        mkdir -p $SCCACHE_DIR
+        echo ""
+
+        echo "----- Remove old postgres -----"
+        sudo apt remove -y postgres*
+        echo ""
+
+        echo "----- Set up PostgreSQL Apt repository -----"
+        sudo apt-get install -y wget gnupg
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null && \
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        echo "----- Install system dependencies and PostgreSQL version $PG_VER -----"
+        sudo apt-get install -y \
+          build-essential \
+          clang \
+          clang-11 \
+          gcc \
+          libssl-dev \
+          libz-dev \
+          llvm-11 \
+          make \
+          pkg-config \
+          strace \
+          zlib1g-dev
+        echo ""
+
+        echo "----- Print env -----"
+        env
+        echo ""
+
+        echo "----- Get cargo version -----"
+        cargo --version
+        echo ""
+
+    - name: Install release version of PostgreSQL
+      if: matrix.version != 'pg16'
+      run: |
+        echo "----- Set up PostgreSQL Apt repository -----"
+        sudo apt-get install -y wget gnupg
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        sudo apt-get install -y \
+          postgresql-$PG_VER \
+          postgresql-server-dev-$PG_VER
+
+    - name: Install develoment version of PostgreSQL
+      if: matrix.version == 'pg16'
+      run: |
+        echo "----- Set up PostgreSQL Apt repository -----"
+        sudo apt-get install -y wget gnupg
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
+        sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ $(lsb_release -s -c)-pgdg-snapshot main 16"
+        sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ $(lsb_release -s -c)-pgdg main 16"
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        sudo apt-get install -y \
+          postgresql-$PG_VER \
+          postgresql-server-dev-$PG_VER
+
+    - name: Set up Postgres permissions
+      run: sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          /home/runner/.cargo
+        key: v0-plrust-x86_64-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
+
+    - name: Cache sccache directory
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          /home/runner/.cache/sccache
+        key: v0-plrust-x86_64-sccache-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain.toml', 'plrustc/.cargo/config.toml', '.github/workflows/ci.yml', '.cargo/config') }}
+
+    - name: Start sccache server
+      run: sccache --start-server && sccache --show-stats
+
+    - name: sccache dir
+      run: ls -lath /home/runner/.cache/sccache
+
+    # See <plrust-root>/.github/scripts/install_cargo_pgrx.sh for more details
+    - name: Install cargo-pgrx defined in plrust/Cargo.toml
+      run: |
+        . $GITHUB_WORKSPACE/.github/scripts/install_cargo_pgrx.sh
+        install_cargo_pgrx
+
+    - name: Print sccache stats
+      run: sccache --show-stats
+
+    - name: Install llvm-tools-preview
+      run: rustup component add llvm-tools-preview rustc-dev
+
+    - name: Create protected files
+      run: |
+        sudo mkdir -p /var/ci-stuff/secret_rust_files
+        sudo echo "const FOO:i32 = 7;" /var/ci-stuff/secret_rust_files/const_foo.rs
+        sudo echo "const BAR:i32 = 8;" /var/ci-stuff/const_bar.rs
+        sudo chmod -R 600 /var/ci-stuff/secret_rust_files
+      if: matrix.target == 'postgrestd'
+
+    - name: Test plrustc
+      run: cd plrustc && cargo test -p plrustc
+
+    - name: Print sccache stats
+      run: sccache --show-stats
+
+    - name: Install plrustc
+      run: cd plrustc && ./build.sh && cp ../build/bin/plrustc ~/.cargo/bin
+
+    - name: Print sccache stats
+      run: sccache --show-stats
+
+    - name: Run 'cargo pgrx init' against system-level ${{ matrix.version }}
+      run: cargo pgrx init --pg$PG_VER $(which pg_config)
+
+    - name: Test PL/rust as "untrusted"
+      if: matrix.target == 'host'
+      run: cargo test --all --features "pg$PG_VER" --no-default-features
+
+    - name: Test PL/rust as "trusted" (inc. postgrestd)
+      if: matrix.target == 'postgrestd'
+      run: cd plrust && STD_TARGETS="x86_64-postgres-linux-gnu" ./build && cargo test --verbose --no-default-features --features "pg$PG_VER trusted"
+
+    - name: Print sccache stats
+      run: sccache --show-stats
+
+    - name: sccache dir
+      run: ls -lath /home/runner/.cache/sccache
+
+    - name: Stop sccache server
+      run: sccache --stop-server || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6186d4aa5911be4c00b52e555779deece35a7563c87fcfe794407dc2e9cc4dc1"
+checksum = "2d0cc681e65b3ce728b66bb63c22219b97a879f83afebbb9fdf19ffa0eccad7e"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.3",
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479a66a8c582e0fdf101178473315cb13eaa10829c154db742c35ec0279cdaec"
+checksum = "e65e023743b5640fe97b8b4bf619b9fffe165995fed3570adce2f8e9fb00580d"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45c557631217a13859e223899c01d35982ef0c860ee5ab65af496f830b1316"
+checksum = "5e19005159334ee5f1ecdc6491e74ddb19c249b1d109d868534c53eaf6121a09"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde896a17c638b6475d6fc12b571a176013a8486437bbc8a64ac2afb8ba5d58"
+checksum = "c7c8bddab264f285209530d5b4bc22823f1f221e4d68c023a6f6a24dc0b0b191"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e9abc71b018d90aa9b7a34fedf48b76da5d55c04d2ed2288096827bebbf403"
+checksum = "929d7ec12b30c12c7fc16d46cbc96a7863047b2794e58001bf0dd21e955bdded"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ac4ffedfa247f9d51421e4e2ac18c33d8d674350bad730f3fe5736bf298612"
+checksum = "15a831c53785d0a86f9db1fac84f13e54415b11208a6fc0b28b9746023241704"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1159,7 +1159,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plrust"
-version = "1.2.3"
+version = "1.2.4-beta.pg16b2"
 dependencies = [
  "base64",
  "cfg-if",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "plrust-trusted-pgrx"
-version = "1.2.3"
+version = "1.2.4-beta.pg16b2"
 dependencies = [
  "pgrx",
 ]
@@ -1406,7 +1406,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1426,7 +1426,7 @@ checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1437,9 +1437,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "remove_dir_all"

--- a/plrust-trusted-pgrx/Cargo.toml
+++ b/plrust-trusted-pgrx/Cargo.toml
@@ -15,10 +15,11 @@ crate-type = ["rlib"]
 pg13 = ["pgrx/pg13"]
 pg14 = ["pgrx/pg14"]
 pg15 = ["pgrx/pg15"]
+pg16 = ["pgrx/pg16"]
 
 [dependencies]
 # changing the pgrx version will likely require at least a minor version bump to this create
-pgrx = { version = "=0.9.7", features = [ "no-schema-generation" ], default-features = false }
+pgrx = { version = "0.10.0-beta.0", features = [ "no-schema-generation" ], default-features = false }
 
 [package.metadata.docs.rs]
 features = ["pg14"]

--- a/plrust-trusted-pgrx/Cargo.toml
+++ b/plrust-trusted-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust-trusted-pgrx"
-version = "1.2.3"
+version = "1.2.4-beta.pg16b2"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust"
-version = "1.2.3"
+version = "1.2.4-beta.pg16b2"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL Open Source License"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -17,6 +17,7 @@ default = ["pg14"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 # is plrust to be compiled as a "trusted" language handler, meaning it requires postgrestd at runtime
 trusted = []
 pg_test = []
@@ -35,15 +36,15 @@ home = "0.5.5" # where can we find cargo?
 # working with our entry in pg_catalog.pg_proc
 base64 = "0.21.2"
 flate2 = "1.0.26"
-serde = "1.0.164"
-serde_json = "1.0.97"
+serde = "1.0.171"
+serde_json = "1.0.100"
 
 # pgrx core details
-pgrx = { version = "=0.9.7" }
+pgrx = { version = "0.10.0-beta.0" }
 
 # language handler support
 libloading = "0.8.0"
-toml = "0.7.4"
+toml = "0.7.6"
 tempdir = "0.3.7" # for building crates
 tempfile = "3.6.0"
 
@@ -67,7 +68,7 @@ memfd = "0.6.3" # for anonymously writing/loading user function .so
 
 
 [dev-dependencies]
-pgrx-tests = { version = "=0.9.7" }
+pgrx-tests = { version = "0.10.0-beta.0" }
 tempdir = "0.3.7"
 once_cell = "1.18.0"
-toml = "0.7.4"
+toml = "0.7.6"

--- a/plrust/src/allow_list.rs
+++ b/plrust/src/allow_list.rs
@@ -365,7 +365,8 @@ pub fn load_allowlist() -> eyre::Result<AllowList> {
     let path = PathBuf::from_str(
         &PLRUST_ALLOWED_DEPENDENCIES
             .get()
-            .ok_or(Error::NotConfigured)?,
+            .ok_or(Error::NotConfigured)?
+            .to_str()?,
     )
     .map_err(|_| Error::InvalidPath)?;
 

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -55,6 +55,7 @@ pub mod tests;
 
 use error::PlRustError;
 use pgrx::{pg_getarg, prelude::*};
+use std::ffi::CStr;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub use tests::pg_test;
@@ -86,7 +87,9 @@ $$;
 // This enables the code checking not only for `unsafe {}`
 // but also "unsafe attributes" which are considered unsafe
 // but don't have the `unsafe` token.
-const DEFAULT_LINTS: &'static str = "\
+const DEFAULT_LINTS: &'static CStr = unsafe {
+    CStr::from_bytes_with_nul_unchecked(
+        b"\
     plrust_extern_blocks, \
     plrust_lifetime_parameterized_traits, \
     implied_bounds_entailment, \
@@ -108,7 +111,9 @@ const DEFAULT_LINTS: &'static str = "\
     suspicious_auto_trait_impls, \
     where_clauses_object_safety, \
     soft_unstable\
-";
+\0",
+    )
+};
 
 #[pg_guard]
 fn _PG_init() {

--- a/plrust/src/user_crate/cargo.rs
+++ b/plrust/src/user_crate/cargo.rs
@@ -47,7 +47,7 @@ pub(crate) fn cargo(
 fn configure_path(command: &mut Command) -> eyre::Result<()> {
     if let Some(path) = PLRUST_PATH_OVERRIDE.get() {
         // we were configured with an explicit $PATH to use
-        command.env("PATH", path);
+        command.env("PATH", path.to_str()?);
     } else {
         let is_empty = match std::env::var("PATH") {
             Ok(s) if s.trim().is_empty() => true,

--- a/plrust/src/user_crate/lint.rs
+++ b/plrust/src/user_crate/lint.rs
@@ -93,6 +93,8 @@ pub(crate) fn compile_lints() -> LintSet {
     PLRUST_COMPILE_LINTS
         .get()
         .unwrap_or_default()
+        .to_str()
+        .expect("plrust.compile_lints is not valid UTF8")
         .split(',')
         .filter(|x| !x.is_empty())
         .map(|s| s.trim().into())
@@ -128,6 +130,8 @@ pub(crate) fn required_lints() -> LintSet {
     let mut configured = PLRUST_REQUIRED_LINTS
         .get()
         .unwrap_or_default()
+        .to_str()
+        .expect("plrust.required_lints is not valid UTF8")
         .split(',')
         .filter_map(filter_map)
         .collect::<LintSet>();

--- a/plrustc/Cargo.lock
+++ b/plrustc/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "plrustc"
-version = "1.2.3"
+version = "1.2.4-beta.pg16b2"
 dependencies = [
  "compiletest_rs",
  "libc",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustfix"

--- a/plrustc/plrustc/Cargo.toml
+++ b/plrustc/plrustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrustc"
-version = "1.2.3"
+version = "1.2.4-beta.pg16b2"
 edition = "2021"
 description = "`rustc_driver` wrapper for plrust"
 license = "PostgreSQL"

--- a/plrustc/plrustc/Cargo.toml
+++ b/plrustc/plrustc/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/tcdi/plrust/"
 repository = "https://github.com/tcdi/plrust/"
 
 [dependencies]
-libc = "0.2.146"
+libc = "0.2.147"
 once_cell = "1.18.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Other than upgrading to pgrx v0.10.0-beta.0, the only changes here are that string `GucSetting`s are now represented as `GucSetting<Option<&'static CStr>>`.

This is "WIP" since it's "beta" for both pgrx and pg16.

I think whenever pgrx v0.10.0 goes GA then we can merge this, regardless of the state of Postgres 16.  Then we'll just release new point releases (or whatever we'd need to do otherwise) as new 16 betas/rcs come out.