### PR TITLE
Drop old tempdir dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,12 +512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,7 +1174,6 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.25",
- "tempdir",
  "tempfile",
  "thiserror",
  "toml",
@@ -1223,7 +1216,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -1281,26 +1274,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1310,23 +1290,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1357,15 +1322,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1440,15 +1396,6 @@ name = "regex-syntax"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -1738,16 +1685,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -44,7 +44,6 @@ pgrx = { version = "=0.9.7" }
 # language handler support
 libloading = "0.8.0"
 toml = "0.7.4"
-tempdir = "0.3.7" # for building crates
 tempfile = "3.6.0"
 
 # error handling, tracing, formatting
@@ -68,6 +67,5 @@ memfd = "0.6.3" # for anonymously writing/loading user function .so
 
 [dev-dependencies]
 pgrx-tests = { version = "=0.9.7" }
-tempdir = "0.3.7"
 once_cell = "1.18.0"
 toml = "0.7.4"

--- a/plrust/src/tests.rs
+++ b/plrust/src/tests.rs
@@ -1403,10 +1403,10 @@ insert into people (p) values (make_person('Dr. Beverly Crusher of the Starship 
 #[cfg(any(test, feature = "pg_test"))]
 pub mod pg_test {
     use once_cell::sync::Lazy;
-    use tempdir::TempDir;
+    use tempfile::{tempdir, TempDir};
 
     static WORK_DIR: Lazy<String> = Lazy::new(|| {
-        let work_dir = TempDir::new("plrust-tests").expect("Couldn't create tempdir");
+        let work_dir = tempdir().expect("Couldn't create tempdir");
         format!("plrust.work_dir='{}'", work_dir.path().display())
     });
     static LOG_LEVEL: &str = "plrust.tracing_level=trace";
@@ -1414,8 +1414,7 @@ pub mod pg_test {
     static PLRUST_ALLOWED_DEPENDENCIES_FILE_NAME: &str = "allowed_deps.toml";
     static PLRUST_ALLOWED_DEPENDENCIES_FILE_DIRECTORY: Lazy<TempDir> = Lazy::new(|| {
         use std::io::Write;
-        let temp_allowed_deps_dir =
-            TempDir::new("plrust-allowed-deps").expect("Couldnt create tempdir");
+        let temp_allowed_deps_dir = tempdir().expect("Couldnt create tempdir");
 
         let file_path = temp_allowed_deps_dir
             .path()


### PR DESCRIPTION
tempfile provides functions for tempdirs too,
so we do not need an old, deprecated dep.
This also gets rid of a minor security advisory,
not actually exploitable in our usage.