### PR TITLE
Change plrust.allowed_dependencies to sighup context

### DIFF
--- a/doc/src/dependencies.md
+++ b/doc/src/dependencies.md
@@ -145,5 +145,6 @@ $$;
 ### Operational Notes
 
 - The dependency allow-list file path must be set in `plrust.allowed_dependencies` GUC value in `postgresql.conf`.
+- Changing the GUC value requires a configuration reload on the database to take effect.
 - The file must be readable by the user that runs Postgres backend connections. Typically, this user is named `postgres`.
 - Every time a `CREATE FUNCTION ... LANGUAGE plrust` statement is executed, the file is read, parsed, and validated. This arrangement allows administrators to edit it without needing to restart the Postgres cluster.

--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -66,7 +66,7 @@ pub(crate) fn init() {
         "The full path of a toml file containing crates and versions allowed when creating PL/Rust functions",
         "The full path of a toml file containing crates and versions allowed when creating PL/Rust functions",
         &PLRUST_ALLOWED_DEPENDENCIES,
-        GucContext::Postmaster,
+        GucContext::Sighup,
         GucFlags::default(),
     );
 


### PR DESCRIPTION
Since there is no technical to set `plrust.allowed_dependencies` to `Postmaster` context which requires engine restart to change its value, we can change its context to `sighup` such that the guc can be modified dynamically to provide more flexibility when using allowlisted crates.

---

## Testing 

- Origin value is `/tmp/old.toml`
```
(23-07-19 16:04:25) [~]
$ > psql -d postgres -c "show plrust.allowed_dependencies"
 plrust.allowed_dependencies
-----------------------------
 /tmp/old.toml
(1 row)
```

- Change value to `/tmp/new.toml`
```
(23-07-19 16:04:27) [~]
$ > vim pg_data/postgresql.conf

(23-07-19 16:04:37) [~]
$ > cat pg_data/postgresql.conf | grep plrust.allowed_dependencies
plrust.allowed_dependencies = '/tmp/new.toml'
```

- Reload engine and new value is applied
```
(23-07-19 16:04:43) [~]
$ > psql -d postgres -c "select pg_reload_conf()"
 pg_reload_conf
----------------
 t
(1 row)

(23-07-19 16:04:45) [~]
$ > psql -d postgres -c "show plrust.allowed_dependencies"
 plrust.allowed_dependencies
-----------------------------
 /tmp/new.toml
(1 row)
```


