### PR TITLE
Bump to Rust 1.71.1

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -6,4 +6,4 @@ src = "src"
 title = "PL/Rust Guide"
 
 [preprocessor.variables.variables]
-toolchain_ver = "1.70.0"
+toolchain_ver = "1.71.0"

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -6,4 +6,4 @@ src = "src"
 title = "PL/Rust Guide"
 
 [preprocessor.variables.variables]
-toolchain_ver = "1.71.0"
+toolchain_ver = "1.71.1"

--- a/doc/src/install-plrust-on-debian-ubuntu.md
+++ b/doc/src/install-plrust-on-debian-ubuntu.md
@@ -28,7 +28,7 @@ Where:
 Example:
 
 ```
-plrust-trusted-1.2.3_1.70.0-debian-pg15-amd64.deb
+plrust-trusted-1.2.3_1.71.0-debian-pg15-amd64.deb
 ```
 
 ## Preparing the environment

--- a/doc/src/install-plrust-on-debian-ubuntu.md
+++ b/doc/src/install-plrust-on-debian-ubuntu.md
@@ -28,7 +28,7 @@ Where:
 Example:
 
 ```
-plrust-trusted-1.2.3_1.71.0-debian-pg15-amd64.deb
+plrust-trusted-1.2.3_1.71.1-debian-pg15-amd64.deb
 ```
 
 ## Preparing the environment

--- a/plrust/build
+++ b/plrust/build
@@ -66,7 +66,7 @@ fi
         git pull
         git submodule update --init --recursive
     else
-        git clone https://github.com/tcdi/postgrestd.git --branch "rust-1.70.0" --recurse-submodules
+        git clone https://github.com/tcdi/postgrestd.git --branch "rust-1.71.0" --recurse-submodules
         cd ./postgrestd
     fi
     rm -f rust-toolchain.toml

--- a/plrust/build
+++ b/plrust/build
@@ -66,7 +66,7 @@ fi
         git pull
         git submodule update --init --recursive
     else
-        git clone https://github.com/tcdi/postgrestd.git --branch "rust-1.71.0" --recurse-submodules
+        git clone https://github.com/tcdi/postgrestd.git --branch "rust-1.71.1" --recurse-submodules
         cd ./postgrestd
     fi
     rm -f rust-toolchain.toml

--- a/plrustc/build.sh
+++ b/plrustc/build.sh
@@ -25,8 +25,8 @@ fi
 export RUSTC_BOOTSTRAP=1
 
 version=$($RUSTC --version | cut -d ' ' -f 2)
-if [ "$version" != "1.70.0" ]; then
-    echo "rustc ('$RUSTC') is not version 1.70.0" >&2
+if [ "$version" != "1.71.0" ]; then
+    echo "rustc ('$RUSTC') is not version 1.71.0" >&2
     exit 1
 fi
 

--- a/plrustc/build.sh
+++ b/plrustc/build.sh
@@ -25,8 +25,8 @@ fi
 export RUSTC_BOOTSTRAP=1
 
 version=$($RUSTC --version | cut -d ' ' -f 2)
-if [ "$version" != "1.71.0" ]; then
-    echo "rustc ('$RUSTC') is not version 1.71.0" >&2
+if [ "$version" != "1.71.1" ]; then
+    echo "rustc ('$RUSTC') is not version 1.71.1" >&2
     exit 1
 fi
 

--- a/plrustc/plrustc/uitests/ice_hook.rs
+++ b/plrustc/plrustc/uitests/ice_hook.rs
@@ -3,6 +3,7 @@
 // normalize-stderr-test: "plrustc version: .*" -> "plrustc version: <version here>"
 // normalize-stderr-test: "force_ice.rs:\d*:\d*" -> "force_ice.rs"
 // normalize-stderr-test: "(?ms)query stack during panic:\n.*end of query stack\n" -> ""
+// normalize-stderr-test: "note: rustc .*? running on .*" -> "note: rustc <version here> running on <target here>"
 #![crate_type = "lib"]
 // The comments above are to clean up file/line/version numbers, backtrace info,
 // etc. We want to avoid ice_hook.stderr changing more than is needed.

--- a/plrustc/plrustc/uitests/ice_hook.stderr
+++ b/plrustc/plrustc/uitests/ice_hook.stderr
@@ -1,12 +1,13 @@
 thread 'rustc' panicked at 'Here is your ICE', plrustc/src/lints/force_ice.rs
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
-error: internal compiler error: unexpected panic
+error: the compiler unexpectedly panicked. this is a bug.
 
-note: `plrustc` unexpectedly panicked. This is probably a bug.
+note: we would appreciate a bug report: https://github.com/tcdi/plrust/issues/new
 
-note: Please file a bug report at <https://github.com/tcdi/plrust/issues/new>
+note: rustc 1.71.0 (8ede3aae2 2023-07-12) running on aarch64-apple-darwin
 
-note: plrustc version: <version here>
+note: compiler flags: -C prefer-dynamic -Z ui-testing
 
-thread panicked while panicking. aborting.
+query stack during panic:
+thread panicked while processing panic. aborting.

--- a/plrustc/plrustc/uitests/ice_hook.stderr
+++ b/plrustc/plrustc/uitests/ice_hook.stderr
@@ -5,7 +5,7 @@ error: the compiler unexpectedly panicked. this is a bug.
 
 note: we would appreciate a bug report: https://github.com/tcdi/plrust/issues/new
 
-note: rustc 1.71.0 (8ede3aae2 2023-07-12) running on aarch64-apple-darwin
+note: rustc <version here> running on <target here>
 
 note: compiler flags: -C prefer-dynamic -Z ui-testing
 

--- a/plrustc/plrustc/uitests/tuple_struct_self_pat_box.stderr
+++ b/plrustc/plrustc/uitests/tuple_struct_self_pat_box.stderr
@@ -1,10 +1,9 @@
-error: `Self` pattern on tuple struct used to access private field
+error[E0603]: tuple struct constructor `std::boxed::Box` is private
   --> $DIR/tuple_struct_self_pat_box.rs:10:13
    |
 LL |         let Self(ptr, _) = self;
    |             ^^^^^^^^^^^^
-   |
-   = note: `-F plrust-tuple-struct-self-pattern` implied by `-F plrust-lints`
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0603`.

--- a/plrustc/plrustc/uitests/tuple_struct_self_pat_local_priv.stderr
+++ b/plrustc/plrustc/uitests/tuple_struct_self_pat_local_priv.stderr
@@ -1,10 +1,9 @@
-error: `Self` pattern on tuple struct used to access private field
+error[E0603]: tuple struct constructor `my::Foo` is private
   --> $DIR/tuple_struct_self_pat_local_priv.rs:8:13
    |
 LL |         let Self(s) = self;
    |             ^^^^^^^
-   |
-   = note: `-F plrust-tuple-struct-self-pattern` implied by `-F plrust-lints`
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0603`.

--- a/plrustc/rust-toolchain.toml
+++ b/plrustc/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.71.1"
 components = [ "rustfmt", "rust-src", "rustc-dev", "cargo", "llvm-tools" ]
 targets = [ ]
 profile = "minimal"

--- a/plrustc/rust-toolchain.toml
+++ b/plrustc/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"
 components = [ "rustfmt", "rust-src", "rustc-dev", "cargo", "llvm-tools" ]
 targets = [ ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"
 components = [ "rustfmt", "rust-src", "rustc-dev", "llvm-tools" ]
 targets = [ ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.71.1"
 components = [ "rustfmt", "rust-src", "rustc-dev", "llvm-tools" ]
 targets = [ ]
 profile = "minimal"


### PR DESCRIPTION
This had an associated CVE so it seems important. The `postgrestd` side of the update is at https://github.com/tcdi/postgrestd/pull/48, and is just about as trivial as this one (only hard part was realizing that `git subtree pull` doing nothing was actually not an error).

Closes #359, since this PR supercedes that one and includes all its commits
