### PR TITLE
Prepare v1.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        version: ["pg13", "pg14", "pg15"]
+        version: ["pg13", "pg14", "pg15", "pg16"]
         target: ["host", "postgrestd"]
       fail-fast: false
 
@@ -212,7 +212,7 @@ jobs:
 
     strategy:
       matrix:
-        version: ["pg13", "pg14", "pg15"]
+        version: ["pg13", "pg14", "pg15", "pg16"]
         os: ["ubuntu-latest"]
         # it would be nice to other contributors to return "macos-11" to the above array
         target: ["host", "postgrestd"]
@@ -222,7 +222,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up (Linux) prerequisites and environment
-      if: matrix.os == 'ubuntu-latest'
       run: |
         echo ""
 
@@ -265,14 +264,8 @@ jobs:
           llvm-11 \
           make \
           pkg-config \
-          postgresql-$PG_VER \
-          postgresql-server-dev-$PG_VER \
           strace \
           zlib1g-dev
-        echo ""
-
-        echo "----- Set up Postgres permissions -----"
-        sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
         echo ""
 
         echo "----- Print env -----"
@@ -282,6 +275,39 @@ jobs:
         echo "----- Get cargo version -----"
         cargo --version
         echo ""
+
+    - name: Install release version of PostgreSQL
+      if: matrix.version != 'pg16'
+      run: |
+        echo "----- Set up PostgreSQL Apt repository -----"
+        sudo apt-get install -y wget gnupg
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        sudo apt-get install -y \
+          postgresql-"$PG_VER" \
+          postgresql-server-dev-"$PG_VER"
+
+    - name: Install development version of PostgreSQL
+      if: matrix.version == 'pg16'
+      run: |
+        echo "----- Set up PostgreSQL Apt repository -----"
+        sudo apt-get install -y wget gnupg
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
+        sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ $(lsb_release -s -c)-pgdg-snapshot main 16"
+        sudo add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ $(lsb_release -s -c)-pgdg main 16"
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        sudo apt-get install -y \
+          postgresql-"$PG_VER" \
+          postgresql-server-dev-"$PG_VER"
+
+    - name: Set up Postgres permissions
+      run: sudo chmod a+rwx "$(/usr/lib/postgresql/"$PG_VER"/bin/pg_config --pkglibdir)" "$(/usr/lib/postgresql/"$PG_VER"/bin/pg_config --sharedir)"/extension /var/run/postgresql/
 
     - name: Cache cargo registry
       uses: actions/cache@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "plrust-tests"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "once_cell",
  "pgrx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plrust"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "base64",
  "cfg-if",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "plrust-trusted-pgrx"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "pgrx",
 ]

--- a/plrust-tests/Cargo.toml
+++ b/plrust-tests/Cargo.toml
@@ -11,6 +11,7 @@ default = ["pg13"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 trusted = []
 

--- a/plrust-tests/Cargo.toml
+++ b/plrust-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust-tests"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 
 [lib]

--- a/plrust-trusted-pgrx/Cargo.toml
+++ b/plrust-trusted-pgrx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust-trusted-pgrx"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL"
@@ -15,6 +15,7 @@ crate-type = ["rlib"]
 pg13 = ["pgrx/pg13"]
 pg14 = ["pgrx/pg14"]
 pg15 = ["pgrx/pg15"]
+pg16 = ["pgrx/pg16"]
 
 [dependencies]
 # changing the pgrx version will likely require at least a minor version bump to this create

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrust"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["TCDI <opensource@tcdi.com>"]
 edition = "2021"
 license = "PostgreSQL Open Source License"
@@ -17,6 +17,7 @@ default = ["pg14"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 # is plrust to be compiled as a "trusted" language handler, meaning it requires postgrestd at runtime
 trusted = []
 pg_test = []
@@ -33,13 +34,13 @@ semver = "1.0.18"
 home = "0.5.5" # where can we find cargo?
 
 # working with our entry in pg_catalog.pg_proc
-base64 = "0.21.3"
-flate2 = "1.0.27"
-serde = "1.0.188"
-serde_json = "1.0.105"
+base64 = "0.21.2"
+flate2 = "1.0.26"
+serde = "1.0.183"
+serde_json = "1.0.104"
 
 # pgrx core details
-pgrx = { version = "=0.10.0" }
+pgrx = { version = "0.10.0" }
 
 # language handler support
 libloading = "0.8.0"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -40,7 +40,7 @@ serde = "1.0.188"
 serde_json = "1.0.105"
 
 # pgrx core details
-pgrx = { version = "0.10.0" }
+pgrx = { version = "=0.10.0" }
 
 # language handler support
 libloading = "0.8.0"

--- a/plrust/Cargo.toml
+++ b/plrust/Cargo.toml
@@ -34,10 +34,10 @@ semver = "1.0.18"
 home = "0.5.5" # where can we find cargo?
 
 # working with our entry in pg_catalog.pg_proc
-base64 = "0.21.2"
-flate2 = "1.0.26"
-serde = "1.0.183"
-serde_json = "1.0.104"
+base64 = "0.21.3"
+flate2 = "1.0.27"
+serde = "1.0.188"
+serde_json = "1.0.105"
 
 # pgrx core details
 pgrx = { version = "0.10.0" }

--- a/plrust/src/allow_list.rs
+++ b/plrust/src/allow_list.rs
@@ -486,10 +486,6 @@ pub fn load_allowlist() -> eyre::Result<AllowList> {
     let path = PathBuf::from_str(
         &PLRUST_ALLOWED_DEPENDENCIES
             .get()
-            .map(|cstr| {
-                cstr.to_str()
-                    .expect("plrust.allowed_dependencies is not valid UTF8")
-            })
             .ok_or(Error::NotConfigured)?,
     )
     .map_err(|_| Error::InvalidPath)?;

--- a/plrust/src/allow_list.rs
+++ b/plrust/src/allow_list.rs
@@ -486,7 +486,8 @@ pub fn load_allowlist() -> eyre::Result<AllowList> {
     let path = PathBuf::from_str(
         &PLRUST_ALLOWED_DEPENDENCIES
             .get()
-            .ok_or(Error::NotConfigured)?,
+            .ok_or(Error::NotConfigured)?
+            .to_str()?,
     )
     .map_err(|_| Error::InvalidPath)?;
 

--- a/plrust/src/gucs.rs
+++ b/plrust/src/gucs.rs
@@ -18,27 +18,20 @@ use pgrx::{pg_sys, GucFlags};
 use crate::target::{CompilationTarget, CrossCompilationTarget, TargetErr};
 use crate::{target, DEFAULT_LINTS};
 
-static PLRUST_WORK_DIR: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-pub(crate) static PLRUST_PATH_OVERRIDE: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-static PLRUST_TRACING_LEVEL: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-pub(crate) static PLRUST_ALLOWED_DEPENDENCIES: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-static PLRUST_COMPILATION_TARGETS: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-pub(crate) static PLRUST_COMPILE_LINTS: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(DEFAULT_LINTS));
-pub(crate) static PLRUST_REQUIRED_LINTS: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-pub(crate) static PLRUST_TRUSTED_PGRX_VERSION: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(None);
-
-pub(crate) const COMPILED_PGRX_VERSION: &'static str = env!(
-    "PLRUST_TRUSTED_PGRX_VERSION",
-    "unknown `plrust-trusted-pgrx` version.  `build.rs` must not have run successfully"
-);
+static PLRUST_WORK_DIR: GucSetting<Option<&'static str>> = GucSetting::new(None);
+pub(crate) static PLRUST_PATH_OVERRIDE: GucSetting<Option<&'static str>> = GucSetting::new(None);
+static PLRUST_TRACING_LEVEL: GucSetting<Option<&'static str>> = GucSetting::new(None);
+pub(crate) static PLRUST_ALLOWED_DEPENDENCIES: GucSetting<Option<&'static str>> =
+    GucSetting::new(None);
+static PLRUST_COMPILATION_TARGETS: GucSetting<Option<&'static str>> = GucSetting::new(None);
+pub(crate) static PLRUST_COMPILE_LINTS: GucSetting<Option<&'static str>> =
+    GucSetting::new(Some(DEFAULT_LINTS));
+pub(crate) static PLRUST_REQUIRED_LINTS: GucSetting<Option<&'static str>> = GucSetting::new(None);
+pub(crate) static PLRUST_TRUSTED_PGRX_VERSION: GucSetting<Option<&'static str>> =
+    GucSetting::new(Some(env!(
+        "PLRUST_TRUSTED_PGRX_VERSION",
+        "unknown `plrust-trusted-pgrx` version.  `build.rs` must not have run successfully"
+    )));
 
 pub(crate) fn init() {
     GucRegistry::define_string_guc(
@@ -118,7 +111,6 @@ pub(crate) fn work_dir() -> PathBuf {
     PathBuf::from_str(
         &PLRUST_WORK_DIR
             .get()
-            .map(|cstr| cstr.to_str().expect("plrust.work_dir is not valid UTF8"))
             .expect("plrust.work_dir is not set in postgresql.conf"),
     )
     .expect("plrust.work_dir is not a valid path")
@@ -127,12 +119,7 @@ pub(crate) fn work_dir() -> PathBuf {
 pub(crate) fn tracing_level() -> tracing::Level {
     PLRUST_TRACING_LEVEL
         .get()
-        .map(|v| {
-            v.to_str()
-                .expect("plrust.tracing_level is not valid UTF8")
-                .parse()
-                .expect("plrust.tracing_level was invalid")
-        })
+        .map(|v| v.parse().expect("plrust.tracing_level was invalid"))
         .unwrap_or(tracing::Level::INFO)
 }
 
@@ -147,8 +134,6 @@ pub(crate) fn compilation_targets() -> eyre::Result<(
     let other_targets = match PLRUST_COMPILATION_TARGETS.get() {
         None => vec![],
         Some(targets) => targets
-            .to_str()
-            .expect("plrust.compilation_targets is not valid UTF8")
             .split(',')
             .map(str::trim)
             .filter(|s| s != &std::env::consts::ARCH) // make sure we don't include this architecture in the list of other targets
@@ -196,11 +181,7 @@ pub(crate) fn get_pgrx_bindings_for_target(target: &CrossCompilationTarget) -> O
 pub(crate) fn get_trusted_pgrx_version() -> String {
     let version = PLRUST_TRUSTED_PGRX_VERSION
         .get()
-        .map(|cstr| {
-            cstr.to_str()
-                .expect("plrust.plrust_trusted_pgrx is not valid UTF8")
-        })
-        .unwrap_or(COMPILED_PGRX_VERSION);
+        .expect("unable to determine `plrust-trusted-pgrx` version"); // shouldn't happen since we set a known default
 
     // we always want this specific version
     format!("={}", version)

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -56,7 +56,6 @@ pub mod tests;
 use crate::allow_list::AllowedDependencyTuple;
 use error::PlRustError;
 use pgrx::{pg_getarg, prelude::*};
-use std::ffi::CStr;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub use tests::pg_test;
@@ -88,9 +87,7 @@ $$;
 // This enables the code checking not only for `unsafe {}`
 // but also "unsafe attributes" which are considered unsafe
 // but don't have the `unsafe` token.
-const DEFAULT_LINTS: &'static CStr = unsafe {
-    CStr::from_bytes_with_nul_unchecked(
-        b"\
+const DEFAULT_LINTS: &'static str = "\
     plrust_extern_blocks, \
     plrust_lifetime_parameterized_traits, \
     implied_bounds_entailment, \
@@ -111,9 +108,7 @@ const DEFAULT_LINTS: &'static CStr = unsafe {
     suspicious_auto_trait_impls, \
     where_clauses_object_safety, \
     soft_unstable\
-\0", // NOTE:  This is a null-terminated CString.
-    )
-};
+";
 
 #[pg_guard]
 fn _PG_init() {

--- a/plrust/src/lib.rs
+++ b/plrust/src/lib.rs
@@ -56,6 +56,7 @@ pub mod tests;
 use crate::allow_list::AllowedDependencyTuple;
 use error::PlRustError;
 use pgrx::{pg_getarg, prelude::*};
+use std::ffi::CStr;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub use tests::pg_test;
@@ -87,7 +88,9 @@ $$;
 // This enables the code checking not only for `unsafe {}`
 // but also "unsafe attributes" which are considered unsafe
 // but don't have the `unsafe` token.
-const DEFAULT_LINTS: &'static str = "\
+const DEFAULT_LINTS: &'static CStr = unsafe {
+    CStr::from_bytes_with_nul_unchecked(
+        b"\
     plrust_extern_blocks, \
     plrust_lifetime_parameterized_traits, \
     implied_bounds_entailment, \
@@ -108,7 +111,9 @@ const DEFAULT_LINTS: &'static str = "\
     suspicious_auto_trait_impls, \
     where_clauses_object_safety, \
     soft_unstable\
-";
+\0", // NOTE:  This is a null-terminated string as it's used statically as a &CStr
+    )
+};
 
 #[pg_guard]
 fn _PG_init() {

--- a/plrust/src/user_crate/cargo.rs
+++ b/plrust/src/user_crate/cargo.rs
@@ -47,11 +47,7 @@ pub(crate) fn cargo(
 fn configure_path(command: &mut Command) -> eyre::Result<()> {
     if let Some(path) = PLRUST_PATH_OVERRIDE.get() {
         // we were configured with an explicit $PATH to use
-        command.env(
-            "PATH",
-            path.to_str()
-                .expect("plrust.plrust_path_override is not valid UTF8"),
-        );
+        command.env("PATH", path);
     } else {
         let is_empty = match std::env::var("PATH") {
             Ok(s) if s.trim().is_empty() => true,

--- a/plrust/src/user_crate/cargo.rs
+++ b/plrust/src/user_crate/cargo.rs
@@ -47,7 +47,7 @@ pub(crate) fn cargo(
 fn configure_path(command: &mut Command) -> eyre::Result<()> {
     if let Some(path) = PLRUST_PATH_OVERRIDE.get() {
         // we were configured with an explicit $PATH to use
-        command.env("PATH", path);
+        command.env("PATH", path.to_str()?);
     } else {
         let is_empty = match std::env::var("PATH") {
             Ok(s) if s.trim().is_empty() => true,

--- a/plrust/src/user_crate/lint.rs
+++ b/plrust/src/user_crate/lint.rs
@@ -93,6 +93,8 @@ pub(crate) fn compile_lints() -> LintSet {
     PLRUST_COMPILE_LINTS
         .get()
         .unwrap_or_default()
+        .to_str()
+        .expect("plrust.compile_lints is not valid UTF8")
         .split(',')
         .filter(|x| !x.is_empty())
         .map(|s| s.trim().into())
@@ -128,6 +130,8 @@ pub(crate) fn required_lints() -> LintSet {
     let mut configured = PLRUST_REQUIRED_LINTS
         .get()
         .unwrap_or_default()
+        .to_str()
+        .expect("plrust.required_lints is not valid UTF8")
         .split(',')
         .filter_map(filter_map)
         .collect::<LintSet>();

--- a/plrust/src/user_crate/lint.rs
+++ b/plrust/src/user_crate/lint.rs
@@ -93,8 +93,6 @@ pub(crate) fn compile_lints() -> LintSet {
     PLRUST_COMPILE_LINTS
         .get()
         .unwrap_or_default()
-        .to_str()
-        .expect("plrust.plrust_compile_lints is not valid UTF8")
         .split(',')
         .filter(|x| !x.is_empty())
         .map(|s| s.trim().into())
@@ -130,8 +128,6 @@ pub(crate) fn required_lints() -> LintSet {
     let mut configured = PLRUST_REQUIRED_LINTS
         .get()
         .unwrap_or_default()
-        .to_str()
-        .expect("plrust.plrust_required_lints is not valid UTF8")
         .split(',')
         .filter_map(filter_map)
         .collect::<LintSet>();

--- a/plrustc/Cargo.lock
+++ b/plrustc/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "plrustc"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "compiletest_rs",
  "libc",

--- a/plrustc/plrustc/Cargo.toml
+++ b/plrustc/plrustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plrustc"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 description = "`rustc_driver` wrapper for plrust"
 license = "PostgreSQL"


### PR DESCRIPTION
These are the updates for the v1.2.5 release, which includes updating to pgrx v0.10.0 and pg16rc1 support.