### PR TITLE
Updates plrust/build to programmatically get pgrx version

### DIFF
--- a/plrust/build
+++ b/plrust/build
@@ -53,7 +53,7 @@ cargo update -p pgrx
 cargo fetch
 if [ "$CI" != true ]; then
     # Attempt to get pgrx version from cargo tree. Looking for a pattern such as "pgrx v0.10.0"
-    PGRX_VERSION=$(cargo tree | grep -E "\s*pgrx\s+v[0-9]+\.[0-9]+\.[0-9]+" | head -n 1 | cut -f2- -dv)
+    PGRX_VERSION=$(cargo tree --depth 1 --package plrust | grep -E "\s*pgrx\s+v[0-9]+\.[0-9]+\.[0-9]+" | head -n 1 | cut -f2- -dv)
 
     if [ -z "$PGRX_VERSION" ]; then
         echo "Could not determine pgrx version from 'cargo tree'!"

--- a/plrust/build
+++ b/plrust/build
@@ -52,9 +52,18 @@ fi
 cargo update -p pgrx
 cargo fetch
 if [ "$CI" != true ]; then
-    cargo install cargo-pgrx \
-     --version "0.10.0" \
-     --locked # use the Cargo.lock in the pgrx repo
+    # Attempt to get pgrx version from cargo tree. Looking for a pattern such as "pgrx v0.10.0"
+    PGRX_VERSION=$(cargo tree | grep -E "\s*pgrx\s+v[0-9]+\.[0-9]+\.[0-9]+" | head -n 1 | cut -f2- -dv)
+
+    if [ -z "$PGRX_VERSION" ]; then
+        echo "Could not determine pgrx version from 'cargo tree'!"
+        exit 1
+    else
+        echo "Installing cargo-pgrx version $PGRX_VERSION"
+        cargo install cargo-pgrx \
+            --version "$PGRX_VERSION" \
+            --locked # use the Cargo.lock in the pgrx repo
+    fi
 fi
 
 # Don't need to run cargo pgrx init: user might already have set it up,


### PR DESCRIPTION
Addresses: https://github.com/tcdi/plrust/issues/377

When plrust goes through a release cycle, occasionally (read: pretty much "almost" every time) we forget to update the hard-coded pgrx version in the `plrust/build` script due to the fact that our automated release tooling does not consider nor modify the script file. With the changes in this PR, we programmatically get the pgrx version using `cargo tree` and some unix utils magic so that nobody has to think about updating that value ever again upon release.