### PR TITLE
Clear env in user function

### DIFF
--- a/plrust-tests/src/trusted.rs
+++ b/plrust-tests/src/trusted.rs
@@ -190,7 +190,7 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic = "error: the `env` and `option_env` macros are forbidden"]
+    #[should_panic = "environment variable `PATH` not defined at compile time."]
     #[cfg(feature = "trusted")]
     fn plrust_block_env() -> spi::Result<()> {
         let definition = r#"
@@ -204,15 +204,14 @@ mod tests {
 
     #[pg_test]
     #[search_path(@extschema@)]
-    #[should_panic = "error: the `env` and `option_env` macros are forbidden"]
+    #[should_panic = "the `option_env` macro always returns `None` in the PL/Rust user function"]
     #[cfg(feature = "trusted")]
     fn plrust_block_option_env() -> spi::Result<()> {
         let definition = r#"
             CREATE FUNCTION try_get_path() RETURNS text AS $$
-                match option_env!("PATH") {
-                    None => Ok(None),
-                    Some(s) => Ok(Some(s.to_string()))
-                }
+                let v = option_env!("PATH")
+                    .expect("the `option_env` macro always returns `None` in the PL/Rust user function");
+                Ok(Some(v.to_string()))
             $$ LANGUAGE plrust;
         "#;
         Spi::run(definition)

--- a/plrustc/plrustc/src/main.rs
+++ b/plrustc/plrustc/src/main.rs
@@ -49,6 +49,14 @@ impl Callbacks for PlrustcCallbacks {
         }
     }
 }
+fn clear_env() {
+    let all_var_names = std::env::vars_os()
+        .map(|(name, _)| name)
+        .collect::<Vec<_>>();
+    for name in all_var_names {
+        std::env::remove_var(name);
+    }
+}
 
 fn main() {
     rustc_driver::install_ice_hook("https://github.com/tcdi/plrust/issues/new", |_| ());
@@ -58,6 +66,9 @@ fn main() {
         let args =
             rustc_driver::args::arg_expand_all(handler, &std::env::args().collect::<Vec<_>>());
         let config = PlrustcConfig::from_env_and_args(&args);
+        if config.compiling_user_crate() {
+            clear_env();
+        }
         run_compiler(
             args,
             &mut PlrustcCallbacks {


### PR DESCRIPTION
Fixes #393, although changes the semantics to "we catch this with a lint" to "we ensure all environment vars are missing".