### PR TITLE
Update Dockerfile.debian-artifact-build

### DIFF
--- a/.github/docker/Dockerfile.debian-artifact-build
+++ b/.github/docker/Dockerfile.debian-artifact-build
@@ -151,7 +151,7 @@ if ! runuser -l postgres -c 'rustup component list | grep -q "^rustc-dev-$(uname
     exit 1
 fi
 
-if ! runuser -l postgres -c 'rustup toolchain list | grep -q "^$TOOLCHAIN_VER-$(uname -m)\b.*(default)$"'; then
+if ! runuser -l postgres -c 'rustup toolchain list | grep -q "^$TOOLCHAIN_VER-$(uname -m)\b.*default)$"'; then
     echo "[!] The 'postgres' user does not have the default toolchain set to $TOOLCHAIN_VER. Please see package installation instructions on how to do this.";
     exit 1
 fi


### PR DESCRIPTION
apt/dpkg installation was failing 
(The 'postgres' user does not have the default toolchain set to 1.72.0. 
Please see package installation instructions on how to do this.
dpkg: error processing archive, etc.)

because 
`rustup toolchain list` 
returning 
`1.72.0-[...] (active, default)` 
was unmatched by the subsequent grep, expecting only `(default)`.
